### PR TITLE
Remove ambiguity around closing personal accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ A multi-account economy plugin.
 | `bank.set.name.other`        | `setname`      | Set the name of an account owned by another player    | `admin`           |
 | `bank.set.name.personal`     | `setname`      | Allow renaming personal accounts (not recommended)    | `admin`           |
 | `bank.delete.other`          | `delete`       | Delete an account owned by another player             | `admin`           |
-| `bank.delete.personal`       | `delete`       | Bypass `prevent-close-personal`                       | `admin`           |
+| `bank.delete.personal`       | `delete`       | Bypass `prevent-close-last-personal`                  | `admin`           |
 | `bank.history.other`         | `transactions` | List transactions of accounts owned by another player | `admin`           |

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -410,7 +410,12 @@ public class BankCommand implements CommandExecutor, TabCompleter {
                 sender.sendMessage(accountPlaceholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.frozen")), account.get()));
                 return;
             }
-            if (BankAccounts.getInstance().getConfig().getBoolean("prevent-close-personal") && account.get().type == Account.Type.PERSONAL && !sender.hasPermission("bank.delete.personal")) {
+            if (
+                    BankAccounts.getInstance().getConfig().getBoolean("prevent-close-last-personal")
+                    && account.get().type == Account.Type.PERSONAL
+                    && !sender.hasPermission("bank.delete.personal")
+                    && Account.get(account.get().owner, Account.Type.PERSONAL).length == 1
+            ) {
                 sender.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.closing-personal"))));
                 return;
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,11 +33,11 @@ currency:
 # Set to `null` to disable automatically creating a personal account on first join
 starting-balance: 0
 
-# If set to true, players will not be able to close their personal account.
+# If set to true, players will not be able to close their LAST personal account.
 # This is recommended if you are using `starting-balance` as an account will be re-created when the player joins again.
 # If you want to prevent a player from using their personal account, you can freeze it.
 # You can BYPASS this setting using `bank.delete.personal`
-prevent-close-personal: true
+prevent-close-last-personal: true
 
 # Server account
 server-account:
@@ -124,8 +124,8 @@ messages:
         insufficient-funds: "<red>(!) Your account has insufficient funds. You have <gray><balance-formatted></gray></red>"
         # Trying to close an account that has non-zero balance
         closing-balance: "<red>(!) You cannot close an account that has a non-zero balance. This account has <gray><balance-formatted></gray></red>"
-        # Trying to close a personal account and `prevent-close-personal` is enabled
-        closing-personal: "<red>(!) You cannot close your personal account.</red>"
+        # Trying to close a personal account and `prevent-close-last-personal` is enabled
+        closing-personal: "<red>(!) You cannot close your last personal account.</red>"
 
     # Account balance
     # Available placeholders:


### PR DESCRIPTION
Players can have multiple personal accounts. This PR will only prevent them from closing their last personal account if `prevent-close-last-personal` (previously `prevent-close-personal`) is set to `true`.