### PR TITLE
Fixed bug with reversed amounts in `/bank history`

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -626,7 +626,7 @@ public class BankCommand implements CommandExecutor, TabCompleter {
         final SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy HH:mm:ss");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         boolean isSender = transaction.from.id.equals(account.id);
-        final BigDecimal amount = !isSender ? transaction.amount.negate() : transaction.amount;
+        final BigDecimal amount = isSender ? transaction.amount.negate() : transaction.amount;
         final Account other = isSender ? transaction.to : transaction.from;
         message = message
                 .replace("<amount>", amount.toPlainString())


### PR DESCRIPTION
Due to a bug in `/bank history`:

 - when you have received money, the amount shows as negative
 - when you have sent money, the amount shows as positive

In other words, whether the balance shows as positive (money received) or negative (money sent) was reversed.

This PR fixes this issue.