### PR TITLE
Fix SQLite error caused by comments in `init-db/sql.sql`

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -154,7 +154,8 @@ public final class BankAccounts extends JavaPlugin {
             throw e;
         }
         final @NotNull String[] queries = setup.split(";");
-        for (final @NotNull String query : queries) {
+        for (@NotNull String query : queries) {
+            query = query.stripTrailing().stripIndent().replaceAll("^\\s+(?:--.+)*", "");
             if (query.isBlank()) continue;
             try (final @NotNull Connection conn = getDb().getConnection();
                  final @NotNull PreparedStatement stmt = conn.prepareStatement(query)) {


### PR DESCRIPTION
Remove SQL comments from queries when executing using regex