### PR TITLE
Notify admins when there is an update of the plugin

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -2,23 +2,6 @@ package pro.cloudnode.smp.bankaccounts;
 
 import org.jetbrains.annotations.NotNull;
 
-/*public final class BankConfig {
-    public final static @NotNull String DB_DB = "db.db";
-    public final static @NotNull String DB_SQLITE_FILE = "db.sqlite.file";
-    public final static @NotNull String DB_MARIADB_JDBC = "db.mariadb.jdbc";
-    public final static @NotNull String DB_MARIADB_USER = "db.mariadb.user";
-    public final static @NotNull String DB_MARIADB_PASSWORD = "db.mariadb.password";
-    public final static @NotNull String DB_CACHEPREPSTMTS = "db.cachePrepStmts";
-    public final static @NotNull String DB_PREPSTMTCACHESIZE = "db.prepStmtCacheSize";
-    public final static @NotNull String DB_PREPSTMTCACHESQLLIMIT = "db.prepStmtCacheSqlLimit";
-    public final static @NotNull String DB_USESERVERPREPSTMTS = "db.useServerPrepStmts";
-    public final static @NotNull String DB_USELOCALSESSSIONSTATE = "db.useLocalSessionState";
-    public final static @NotNull String DB_REWRITEBATCHEDSTATEMENTS = "db.rewriteBatchedStatements";
-    public final static @NotNull String DB_CACHERESULTSETMETADATA = "db.cacheResultSetMetadata";
-    public final static @NotNull String DB_CACHESERVERCONFIGURATION = "db.cacheServerConfiguration";
-    public final static @NotNull String DB_ELIDESETAUTOCOMMITS = "db.elideSetAutoCommits";
-    public final static @NotNull String DB_MAINTAINTIMESTATS = "db.maintainTimeStats";
-}*/
 public enum BankConfig {
     DB_DB("db.db"),
     DB_SQLITE_FILE("db.sqlite.file"),
@@ -127,7 +110,8 @@ public enum BankConfig {
     MESSAGES_POS_REMOVED("messages.pos-removed"),
     MESSAGES_POS_PURCHASE("messages.pos-purchase"),
     MESSAGES_POS_PURCHASE_SELLER("messages.pos-purchase-seller"),
-    MESSAGES_WHOIS("messages.whois");
+    MESSAGES_WHOIS("messages.whois"),
+    MESSAGES_UPDATE_AVAILABLE("messages.update-available");
 
     private final @NotNull String key;
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -19,7 +19,7 @@ public abstract class Command implements CommandExecutor, TabCompleter {
      * @param message      Message to send.
      * @return Always true.
      */
-    protected static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull Component message) {
+    public static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull Component message) {
         sender.sendMessage(message);
         return true;
     }
@@ -31,7 +31,7 @@ public abstract class Command implements CommandExecutor, TabCompleter {
      * @param placeholders Placeholders to replace.
      * @return Always true.
      */
-    protected static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull String message, final @NotNull TagResolver @NotNull ... placeholders) {
+    public static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull String message, final @NotNull TagResolver @NotNull ... placeholders) {
         sendMessage(sender, MiniMessage.miniMessage().deserialize(message, placeholders));
         return true;
     }
@@ -44,7 +44,7 @@ public abstract class Command implements CommandExecutor, TabCompleter {
      * @param placeholders Placeholders to replace.
      * @return Always true.
      */
-    protected static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull BankConfig path, final @NotNull TagResolver @NotNull ... placeholders) {
+    public static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull BankConfig path, final @NotNull TagResolver @NotNull ... placeholders) {
         return sendMessage(sender, Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString(path.getKey())), placeholders);
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
@@ -6,10 +6,21 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
+import pro.cloudnode.smp.bankaccounts.BankConfig;
+import pro.cloudnode.smp.bankaccounts.Command;
 
 import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class Join implements Listener {
     @EventHandler
@@ -23,6 +34,38 @@ public final class Join implements Listener {
                     new Account(player, Account.Type.PERSONAL, null, BigDecimal.valueOf(startingBalance), false).insert();
                 }
             });
+        }
+        if (player.hasPermission("bank.notify-update")) {
+            final @NotNull BankAccounts plugin = BankAccounts.getInstance();
+            final @NotNull String mcVersion = plugin.getServer().getMinecraftVersion();
+            final @NotNull String pluginName = plugin.getPluginMeta().getName();
+            final @NotNull String pluginVersion = plugin.getPluginMeta().getVersion();
+            try {
+                final @NotNull HttpClient client = HttpClient.newHttpClient();
+                final @NotNull HttpRequest req = HttpRequest.newBuilder()
+                        .uri(URI.create("https://api.modrinth.com/v2/project/Dc8RS2En/version?featured=true&game_versions=[%22" + mcVersion + "%22]"))
+                        .header("User-Agent",
+                                pluginName + "/" + pluginVersion
+                        )
+                        .GET()
+                        .build();
+                final @NotNull HttpResponse<String> res = client.send(req, HttpResponse.BodyHandlers.ofString());
+                if (res.statusCode() < 400 && res.statusCode() >= 200 && res.body() != null) {
+                    final @NotNull Matcher matcher = Pattern.compile("\"version_number\":\"(.+?)\"").matcher(res.body());
+                    if (matcher.find()) {
+                        final @Nullable String latestVersion = matcher.group(1);
+                        if (latestVersion != null && !latestVersion.equals(pluginVersion))
+                            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+                                Command.sendMessage(player, Objects.requireNonNull(plugin.getConfig()
+                                                .getString(BankConfig.MESSAGES_UPDATE_AVAILABLE.getKey()))
+                                        .replace("<version>", latestVersion));
+                            }, 20L);
+                    }
+                }
+            }
+            catch (final @NotNull Exception e) {
+                plugin.getLogger().log(Level.WARNING, "Failed to check for updates", e);
+            }
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -412,3 +412,9 @@ messages:
         <gray>Owned by:</gray> <white><account-owner></white>
         <gray>Type:</gray> <white><account-type></white>
         <gray>ID: <click:copy_to_clipboard:<account-id>><hover:show_text:'<white>Copy to clipboard</white>'><white><account-id></white></hover></click></gray>
+
+
+    # New version available
+    # Placeholders:
+    # <version> - New version
+    update-available: "<hover:show_text:'<white>Click to view update</white><newline><gray> - Changelog & release notes<newline> - Download links'><click:open_url:https://modrinth.com/plugin/bankaccounts/version/<version>><dark_gray>[<green>BankAccounts</green>]</dark_gray> <white>A new version <green><version></green> has been released.</white><newline><gray>Please update to get the latest bug fixes and features.</gray><newline> <green>> Click to view update<green></click></hover>"


### PR DESCRIPTION
When a player joins and has the permission `bank.notify-update`, they are sent a message in chat if there is a new version of the plugin.

> [!NOTE]
> If you would like to disable this, simply do not set this permission. If you are using a wildcard or `/op` (generally not recommended), negate the permission in your permission manager.

> [!IMPORTANT]
> It is vital to always use the latest version of the plugin. Bugs and potential security vulnerabilities are only fixed on the latest version.

Alternatively:

- You can watch this repository for releases. Click `Watch` → `Custom` and select the notifications you would like to receive from GitHub. 
![image](https://github.com/cloudnode-pro/BankAccounts/assets/66572326/22700a0e-d09c-4012-8e1c-55feab3b1886)


- You can follow [the project on Modrinth](https://modrinth.com/plugin/Dc8RS2En) to get a notification on Modrinth whenever a new version is available. 
![image](https://github.com/cloudnode-pro/BankAccounts/assets/66572326/1db9c363-d99b-4c16-94a7-ea7aab4f7c18)
