### PR TITLE
Customisation for account type string and material name translation

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -198,7 +198,7 @@ public class Account {
         return MiniMessage.miniMessage().deserialize(string,
                 Placeholder.unparsed("account", this.name == null ? (this.type == Type.PERSONAL && this.owner.getName() != null ? this.owner.getName() : this.id) : this.name),
                 Placeholder.parsed("account-id", this.id),
-                Placeholder.parsed("account-type", this.type.name),
+                Placeholder.parsed("account-type", this.type.getName()),
                 Placeholder.parsed("account-owner", this.owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) ? "<i>the server</i>" : this.owner.getName() == null ? "<i>unknown player</i>" : this.owner.getName()),
                 Formatter.date("date", LocalDateTime.now(ZoneOffset.UTC))
         ).decoration(TextDecoration.ITALIC, false);
@@ -345,7 +345,7 @@ public class Account {
             String prefix = name.isEmpty() ? "" : name + "-";
             string = string.replace("<" + prefix + "account>", account.name == null ? (account.type == Account.Type.PERSONAL && account.owner.getName() != null ? account.owner.getName() : account.id) : account.name)
                     .replace("<" + prefix + "account-id>", account.id)
-                    .replace("<" + prefix + "account-type>", account.type.name)
+                    .replace("<" + prefix + "account-type>", account.type.getName())
                     .replace("<" + prefix + "account-owner>", account.owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) ? "<i>the server</i>" : account.owner.getName() == null ? "<i>unknown player</i>" : account.owner.getName())
                     .replace("<" + prefix + "balance>", account.balance == null ? "∞" : account.balance.toPlainString())
                     .replace("<" + prefix + "balance-formatted>", BankAccounts.formatCurrency(account.balance))
@@ -392,19 +392,17 @@ public class Account {
         /**
          * Personal, individual, private account
          */
-        PERSONAL("Personal"),
+        PERSONAL,
         /**
          * Account owned by a company or other corporate entity
          */
-        BUSINESS("Business");
+        BUSINESS;
 
         /**
-         * User-friendly name
+         * Get type name (as set in config)
          */
-        public final @NotNull String name;
-
-        Type(final @NotNull String name) {
-            this.name = name;
+        public @NotNull String getName() {
+            return Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.types." + getType(this)));
         }
 
         /**
@@ -426,9 +424,8 @@ public class Account {
         }
 
         public static @NotNull Optional<@NotNull Type> fromString(final @NotNull String name) {
-            for (final @NotNull Type type : Type.values()) {
-                if (type.name.equalsIgnoreCase(name)) return Optional.of(type);
-            }
+            for (final @NotNull Type type : Type.values())
+                if (type.name().equalsIgnoreCase(name)) return Optional.of(type);
             return Optional.empty();
         }
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -310,7 +310,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             int limit = BankAccounts.getInstance().getConfig()
                     .getInt("account-limits." + Account.Type.getType(optionalType.get()));
             if (limit != -1 && accounts.length >= limit)
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_MAX_ACCOUNTS, Placeholder.unparsed("type", optionalType.get().name), Placeholder.unparsed("limit", String.valueOf(BankAccounts
+                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_MAX_ACCOUNTS, Placeholder.unparsed("type", optionalType.get().getName()), Placeholder.unparsed("limit", String.valueOf(BankAccounts
                         .getInstance().getConfig()
                         .getInt("account-limits." + Account.Type.getType(optionalType.get())))));
         }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -310,9 +310,9 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             int limit = BankAccounts.getInstance().getConfig()
                     .getInt("account-limits." + Account.Type.getType(optionalType.get()));
             if (limit != -1 && accounts.length >= limit)
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_MAX_ACCOUNTS, Placeholder.unparsed("type", optionalType.get().getName()), Placeholder.unparsed("limit", String.valueOf(BankAccounts
-                        .getInstance().getConfig()
-                        .getInt("account-limits." + Account.Type.getType(optionalType.get())))));
+                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_MAX_ACCOUNTS, Placeholder.unparsed("type", optionalType
+                        .get().getName()), Placeholder.unparsed("limit", String.valueOf(BankAccounts.getInstance()
+                        .getConfig().getInt("account-limits." + Account.Type.getType(optionalType.get())))));
         }
 
         final @NotNull Account account = new Account(target, optionalType.get(), null, BigDecimal.ZERO, false);
@@ -460,8 +460,8 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
                     .getConfig().getString(BankConfig.MESSAGES_ERRORS_INSUFFICIENT_FUNDS.getKey())), from.get()));
 
-        @Nullable String description = args.length > 3 ? String.join(" ", Arrays.copyOfRange(argsCopy, 3, argsCopy.length))
-                .trim() : null;
+        @Nullable String description = args.length > 3 ? String
+                .join(" ", Arrays.copyOfRange(argsCopy, 3, argsCopy.length)).trim() : null;
         if (description != null && description.length() > 64) description = description.substring(0, 64);
 
         if (description != null && (description.contains("<") || description.contains(">")))
@@ -576,10 +576,10 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
                     .findFirst().orElse(null);
 
             if (!sender.hasPermission("bank.instrument.create.bypass")) {
-                if (item == null)
-                    return sendMessage(sender, BankConfig.MESSAGES_ERRORS_INSTRUMENT_REQUIRES_ITEM, Placeholder.unparsed("material", Objects
-                            .requireNonNull(BankAccounts.getInstance().getConfig()
-                                    .getString(BankConfig.INSTRUMENTS_MATERIAL.getKey())).toLowerCase()));
+                if (item == null) return sendMessage(sender, Objects
+                        .requireNonNull(BankAccounts.getInstance().getConfig()
+                                .getString(BankConfig.MESSAGES_ERRORS_INSTRUMENT_REQUIRES_ITEM.getKey()))
+                        .replace("<material-key>", material.translationKey()), Placeholder.unparsed("material", material.name()));
                 else {
                     final @NotNull ItemStack clone = item.clone();
                     clone.setAmount(1);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -275,8 +275,10 @@ messages:
         # Player not found
         player-not-found: "<red>(!) Player not found.</red>"
         # You must have a specific item to convert to an instrument
-        # Placeholder: <material> - the item type that is required
-        instrument-requires-item: "<red>(!) You must have <gray>x1 <material></gray> in your inventory to create a bank card from.</red>"
+        # Placeholders:
+        # <material> - the item type that is required (the item ID)
+        # <material-key> - item translation key, can be used together with <lang:<material-key>>
+        instrument-requires-item: "<red>(!) You must have <gray>x1 <lang:<material-key>></gray> in your inventory to create a bank card from.</red>"
         # Target player's inventory is full
         # Placeholder: <player> - the target player's name
         target-inventory-full: "<red>(!) The inventory of <gray><player></gray> is full.</red>"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -229,6 +229,13 @@ messages:
     # - <arguments> - The command usage arguments (e.g. "send <from> <to> <amount> [description]")
     command-usage: "<yellow>(!) Usage:</yellow> <white>/<command> <arguments></white>"
 
+    # Account types
+    types:
+        # Personal account
+        0: Personal
+        # Business account
+        1: Business
+
     # Errors
     errors:
         # You have no accounts


### PR DESCRIPTION
The plugin provides private/personal accounts (type id 0) and business accounts (type id 1). You can now choose what these are called in the config.

This also adds an option for `<material-key>` which can be used as `<lang:<material-key>>` to automatically translate the item name to the player's selected Minecraft language.