### PR TITLE
Config and permissions refactor

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -155,20 +155,19 @@ public class Account {
      * Create payment instrument
      */
     public final @NotNull ItemStack createInstrument() {
-        final @NotNull Material material = Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("instruments.material"))));
+        final @NotNull Material material = BankAccounts.getInstance().config().instrumentsMaterial();
         final @NotNull ItemStack instrument = new ItemStack(material);
 
-        final @NotNull String name = Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("instruments.name"));
-        final @NotNull List<String> lore = Objects.requireNonNull(BankAccounts.getInstance().getConfig().getStringList("instruments.lore"));
-        final boolean glint = BankAccounts.getInstance().getConfig().getBoolean("instruments.glint.enabled");
+        final @NotNull String name = BankAccounts.getInstance().config().instrumentsName();
+        final @NotNull List<@NotNull String> lore = BankAccounts.getInstance().config().instrumentsLore();
+        final boolean glint = BankAccounts.getInstance().config().instrumentsGlintEnabled();
 
         final @NotNull ItemMeta meta = instrument.getItemMeta();
         meta.displayName(this.instrumentPlaceholders(name));
         meta.lore(lore.stream().map(this::instrumentPlaceholders).toList());
 
         if (glint) {
-            final @NotNull NamespacedKey key = NamespacedKey.minecraft(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("instruments.glint.enchantment")));
-            final @NotNull Enchantment enchantment = Objects.requireNonNull(EnchantmentWrapper.getByKey(key));
+            final @NotNull Enchantment enchantment = BankAccounts.getInstance().config().instrumentsGlintEnchantment();
             meta.addEnchant(enchantment, 1, true);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         }
@@ -402,7 +401,7 @@ public class Account {
          * Get type name (as set in config)
          */
         public @NotNull String getName() {
-            return Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.types." + getType(this)));
+            return BankAccounts.getInstance().config().messagesTypes(this);
         }
 
         /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -9,7 +9,6 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.enchantments.EnchantmentWrapper;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -10,7 +10,6 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -10,6 +10,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -45,8 +46,13 @@ import java.util.UUID;
 import java.util.logging.Level;
 
 public final class BankAccounts extends JavaPlugin {
+    private final @NotNull BankConfig config = new BankConfig(getConfig());
 
-    public final @NotNull HikariConfig config = new HikariConfig();
+    public @NotNull BankConfig config() {
+        return config;
+    }
+
+    public final @NotNull HikariConfig hikariConfig = new HikariConfig();
     private HikariDataSource dbSource;
 
     public @NotNull HikariDataSource getDb() {
@@ -99,16 +105,16 @@ public final class BankAccounts extends JavaPlugin {
      * Setup database source
      */
     private void setupDbSource() {
-        switch (Objects.requireNonNull(getConfig().getString("db.db"))) {
+        switch (config().dbDb()) {
             case "sqlite" -> {
-                config.setDriverClassName("org.sqlite.JDBC");
-                config.setJdbcUrl("jdbc:sqlite:" + getDataFolder().getAbsolutePath() + "/" + Objects.requireNonNull(getConfig().getString("db.sqlite.file")));
+                hikariConfig.setDriverClassName("org.sqlite.JDBC");
+                hikariConfig.setJdbcUrl("jdbc:sqlite:" + getDataFolder().getAbsolutePath() + "/" + config().dbSqliteFile());
             }
             case "mariadb" -> {
-                config.setDriverClassName(org.mariadb.jdbc.Driver.class.getName());
-                config.setJdbcUrl(Objects.requireNonNull(getConfig().getString("db.mariadb.jdbc")));
-                config.setUsername(Objects.requireNonNull(getConfig().getString("db.mariadb.user")));
-                config.setPassword(Objects.requireNonNull(getConfig().getString("db.mariadb.password")));
+                hikariConfig.setDriverClassName(org.mariadb.jdbc.Driver.class.getName());
+                hikariConfig.setJdbcUrl(config().dbMariadbJdbc());
+                hikariConfig.setUsername(config().dbMariadbUser());
+                hikariConfig.setPassword(config().dbMariadbPassword());
             }
             default -> {
                 getLogger().log(Level.SEVERE, "Invalid database type.");
@@ -116,28 +122,19 @@ public final class BankAccounts extends JavaPlugin {
                 return;
             }
         }
-        if (getConfig().isBoolean("db.cachePrepStmts"))
-            config.addDataSourceProperty("cachePrepStmts", getConfig().getString("db.cachePrepStmts"));
-        if (getConfig().isInt("db.prepStmtCacheSize"))
-            config.addDataSourceProperty("prepStmtCacheSize", getConfig().getString("db.prepStmtCacheSize"));
-        if (getConfig().isInt("db.prepStmtCacheSqlLimit"))
-            config.addDataSourceProperty("prepStmtCacheSqlLimit", getConfig().getString("db.prepStmtCacheSqlLimit"));
-        if (getConfig().isBoolean("db.useServerPrepStmts"))
-            config.addDataSourceProperty("useServerPrepStmts", getConfig().getString("db.useServerPrepStmts"));
-        if (getConfig().isBoolean("db.useLocalSessionState"))
-            config.addDataSourceProperty("useLocalSessionState", getConfig().getString("db.useLocalSessionState"));
-        if (getConfig().isBoolean("db.rewriteBatchedStatements"))
-            config.addDataSourceProperty("rewriteBatchedStatements", getConfig().getString("db.rewriteBatchedStatements"));
-        if (getConfig().isBoolean("db.cacheResultSetMetadata"))
-            config.addDataSourceProperty("cacheResultSetMetadata", getConfig().getString("db.cacheResultSetMetadata"));
-        if (getConfig().isBoolean("db.cacheServerConfiguration"))
-            config.addDataSourceProperty("cacheServerConfiguration", getConfig().getString("db.cacheServerConfiguration"));
-        if (getConfig().isBoolean("db.elideSetAutoCommits"))
-            config.addDataSourceProperty("elideSetAutoCommits", getConfig().getString("db.elideSetAutoCommits"));
-        if (getConfig().isBoolean("db.maintainTimeStats"))
-            config.addDataSourceProperty("maintainTimeStats", getConfig().getString("db.maintainTimeStats"));
 
-        dbSource = new HikariDataSource(config);
+        hikariConfig.addDataSourceProperty("cachePrepStmts", config().dbCachePrepStmts());
+        hikariConfig.addDataSourceProperty("prepStmtCacheSize", config().dbPrepStmtCacheSize());
+        hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", config().dbPrepStmtCacheSqlLimit());
+        hikariConfig.addDataSourceProperty("useServerPrepStmts", config().dbUseServerPrepStmts());
+        hikariConfig.addDataSourceProperty("useLocalSessionState", config().dbUseLocalSessionState());
+        hikariConfig.addDataSourceProperty("rewriteBatchedStatements", config().dbRewriteBatchedStatements());
+        hikariConfig.addDataSourceProperty("cacheResultSetMetadata", config().dbCacheResultSetMetadata());
+        hikariConfig.addDataSourceProperty("cacheServerConfiguration", config().dbCacheServerConfiguration());
+        hikariConfig.addDataSourceProperty("elideSetAutoCommits", config().dbElideSetAutoCommits());
+        hikariConfig.addDataSourceProperty("maintainTimeStats", config().dbMaintainTimeStats());
+
+        dbSource = new HikariDataSource(hikariConfig);
     }
 
     /**
@@ -145,6 +142,7 @@ public final class BankAccounts extends JavaPlugin {
      */
     public static void reload() {
         getInstance().reloadConfig();
+        getInstance().config.config = getInstance().getConfig();
         getInstance().setupDbSource();
         getInstance().initDbWrapper();
         createServerAccount();
@@ -165,7 +163,7 @@ public final class BankAccounts extends JavaPlugin {
             put("mariadb", "db-init/mysql.sql");
             put("sqlite", "db-init/sql.sql");
         }};
-        final @NotNull String db = Objects.requireNonNull(getConfig().getString("db.db"));
+        final @NotNull String db = config().dbDb();
         if (!initFiles.containsKey(db)) {
             getLogger().log(Level.SEVERE, "Invalid database type.");
             getServer().getPluginManager().disablePlugin(this);
@@ -213,8 +211,7 @@ public final class BankAccounts extends JavaPlugin {
      * Get currency symbol
      */
     public static @NotNull String getCurrencySymbol() {
-        final @Nullable String symbol = getInstance().getConfig().getString("currency.symbol");
-        return symbol != null ? symbol : "$";
+        return getInstance().config().currencySymbol();
     }
 
     /**
@@ -224,8 +221,8 @@ public final class BankAccounts extends JavaPlugin {
      */
     public static String formatCurrency(final @Nullable BigDecimal amount) {
         if (amount == null) return getCurrencySymbol() + "∞";
-        final @Nullable String format = getInstance().getConfig().getString("currency.format");
-        return (amount.compareTo(BigDecimal.ZERO) < 0 ? "<red>-" : "") + getCurrencySymbol() + new DecimalFormat(format != null ? format : "#,##0.00").format(amount.abs().setScale(2, RoundingMode.HALF_UP)) + (amount.compareTo(BigDecimal.ZERO) < 0 ? "</red>" : "");
+        final @Nullable String format = getInstance().config().currencyFormat();
+        return (amount.compareTo(BigDecimal.ZERO) < 0 ? "<red>-" : "") + getCurrencySymbol() + new DecimalFormat(format).format(amount.abs().setScale(2, RoundingMode.HALF_UP)) + (amount.compareTo(BigDecimal.ZERO) < 0 ? "</red>" : "");
     }
 
     /**
@@ -272,12 +269,12 @@ public final class BankAccounts extends JavaPlugin {
      * Create server account, if enabled in config
      */
     private static void createServerAccount() {
-        if (getInstance().getConfig().getBoolean("server-account.enabled")) {
+        if (getInstance().config().serverAccountEnabled()) {
             final @NotNull Account[] accounts = Account.get(getConsoleOfflinePlayer());
             if (accounts.length > 0) return;
-            final @Nullable String name = getInstance().getConfig().getString("server-account.name");
-            final @NotNull Account.Type type = Account.Type.getType(getInstance().getConfig().getInt("server-account.type"));
-            final @Nullable BigDecimal balance = Objects.requireNonNull(getInstance().getConfig().getString("server-account.starting-balance")).equals("Infinity") ? null : BigDecimal.valueOf(getInstance().getConfig().getDouble("server-account.starting-balance"));
+            final @Nullable String name = getInstance().config().serverAccountName();
+            final @NotNull Account.Type type = getInstance().config().serverAccountType();
+            final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance().map(BigDecimal::valueOf).orElse(null);
             new Account(getConsoleOfflinePlayer(), type, name, balance, false).insert();
         }
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -436,11 +436,6 @@ public final class BankConfig {
         return Objects.requireNonNull(config.getString("messages.errors.pos-no-permission"));
     }
 
-    // messages.errors.card-no-permission
-    public @NotNull String messagesErrorsCardNoPermission() {
-        return Objects.requireNonNull(config.getString("messages.errors.card-no-permission"));
-    }
-
     // messages.errors.no-card
     public @NotNull String messagesErrorsNoCard() {
         return Objects.requireNonNull(config.getString("messages.errors.no-card"));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -1,126 +1,573 @@
 package pro.cloudnode.smp.bankaccounts;
 
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.jetbrains.annotations.NotNull;
 
-public enum BankConfig {
-    DB_DB("db.db"),
-    DB_SQLITE_FILE("db.sqlite.file"),
-    DB_MARIADB_JDBC("db.mariadb.jdbc"),
-    DB_MARIADB_USER("db.mariadb.user"),
-    DB_MARIADB_PASSWORD("db.mariadb.password"),
-    DB_CACHEPREPSTMTS("db.cachePrepStmts"),
-    DB_PREPSTMTCACHESIZE("db.prepStmtCacheSize"),
-    DB_PREPSTMTCACHESQLLIMIT("db.prepStmtCacheSqlLimit"),
-    DB_USESERVERPREPSTMTS("db.useServerPrepStmts"),
-    DB_USELOCALSESSSIONSTATE("db.useLocalSessionState"),
-    DB_REWRITEBATCHEDSTATEMENTS("db.rewriteBatchedStatements"),
-    DB_CACHERESULTSETMETADATA("db.cacheResultSetMetadata"),
-    DB_CACHESERVERCONFIGURATION("db.cacheServerConfiguration"),
-    DB_ELIDESETAUTOCOMMITS("db.elideSetAutoCommits"),
-    DB_MAINTAINTIMESTATS("db.maintainTimeStats"),
-    CURRENCY_SYMBOL("currency.symbol"),
-    CURRENCY_FORMAT("currency.format"),
-    STARTING_BALANCE("starting-balance"),
-    PREVENT_CLOSE_LAST_PERSONAL("prevent-close-last-personal"),
-    SERVER_ACCOUNT_ENABLED("server-account.enabled"),
-    SERVER_ACCOUNT_NAME("server-account.name"),
-    SERVER_ACCOUNT_TYPE("server-account.type"),
-    SERVER_ACCOUNT_STARTING_BALANCE("server-account.starting-balance"),
-    ACCOUNT_LIMITS_PERSONAL("account-limits.0"),
-    ACCOUNT_LIMITS_BUSINESS("account-limits.1"),
-    TRANSFER_CONFIRMATION_ENABLED("transfer-confirmation.enabled"),
-    TRANSFER_CONFIRMATION_MIN_AMOUNT("transfer-confirmation.min-amount"),
-    TRANSFER_CONFIRMATION_BYPASS_OWN_ACCOUNTS("transfer-confirmation.bypass-own-accounts"),
-    HISTORY_PER_PAGE("history.per-page"),
-    INSTRUMENTS_MATERIAL("instruments.material"),
-    INSTRUMENTS_REQUIRE_ITEM("instruments.require-item"),
-    INSTRUMENTS_NAME("instruments.name"),
-    INSTRUMENTS_LORE("instruments.lore"),
-    INSTRUMENTS_GLINT_ENABLED("instruments.glint.enabled"),
-    INSTRUMENTS_ENCHANTMENT("instruments.glint.enchantment"),
-    POS_ALLOW_PERSONAL("pos.allow-personal"),
-    POS_TITLE("pos.title"),
-    POS_INFO_MATERIAL("pos.info.material"),
-    POS_INFO_GLINT("pos.info.glint"),
-    POS_INFO_NAME_OWNER("pos.info.name-owner"),
-    POS_INFO_NAME_BUYER("pos.info.name-buyer"),
-    POS_INFO_LORE_OWNER("pos.info.lore-owner"),
-    POS_INFO_LORE_BUYER("pos.info.lore-buyer"),
-    POS_DELETE_MATERIAL("pos.delete.material"),
-    POS_DELETE_GLINT("pos.delete.glint"),
-    POS_DELETE_NAME("pos.delete.name"),
-    POS_DELETE_LORE("pos.delete.lore"),
-    POS_CONFIRM_MATERIAL("pos.confirm.material"),
-    POS_CONFIRM_GLINT("pos.confirm.glint"),
-    POS_CONFIRM_NAME("pos.confirm.name"),
-    POS_CONFIRM_LORE("pos.confirm.lore"),
-    POS_DECLINE_MATERIAL("pos.decline.material"),
-    POS_DECLINE_GLINT("pos.decline.glint"),
-    POS_DECLINE_NAME("pos.decline.name"),
-    POS_DECLINE_LORE("pos.decline.lore"),
-    MESSAGES_COMMAND_USAGE("messages.command-usage"),
-    MESSAGES_ERRORS_NO_ACCOUNTS("messages.errors.no-accounts"),
-    MESSAGES_ERRORS_NO_PERMISSION("messages.errors.no-permission"),
-    MESSAGES_ERRORS_ACCOUNT_NOT_FOUND("messages.errors.account-not-found"),
-    MESSAGES_ERRORS_UNKNOWN_COMMAND("messages.errors.unknown-command"),
-    MESSAGES_ERRORS_MAX_ACCOUNTS("messages.errors.max-accounts"),
-    MESSAGES_ERRORS_RENAME_PERSONAL("messages.errors.rename-personal"),
-    MESSAGES_ERRORS_NOT_ACCOUNT_OWNER("messages.errors.not-account-owner"),
-    MESSAGES_ERRORS_FROZEN("messages.errors.frozen"),
-    MESSAGES_ERRORS_SAME_FROM_TO("messages.errors.same-from-to"),
-    MESSAGES_ERRORS_TRANSFER_SELF_ONLY("messages.errors.transfer-self-only"),
-    MESSAGES_ERRORS_TRANSFER_OTHER_ONLY("messages.errors.transfer-other-only"),
-    MESSAGES_ERRORS_INVALID_NUMBER("messages.errors.invalid-number"),
-    MESSAGES_ERRORS_NEGATIVE_TRANSFER("messages.errors.negative-transfer"),
-    MESSAGES_ERRORS_INSUFFICIENT_FUNDS("messages.errors.insufficient-funds"),
-    MESSAGES_ERRORS_CLOSING_BALANCE("messages.errors.closing-balance"),
-    MESSAGES_ERRORS_CLOSING_PERSONAL("messages.errors.closing-personal"),
-    MESSAGES_ERRORS_PLAYER_ONLY("messages.errors.player-only"),
-    MESSAGES_ERRORS_PLAYER_NOT_FOUND("messages.errors.player-not-found"),
-    MESSAGES_ERRORS_INSTRUMENT_REQUIRES_ITEM("messages.errors.instrument-requires-item"),
-    MESSAGES_ERRORS_TARGET_INVENTORY_FULL("messages.errors.target-inventory-full"),
-    MESSAGES_ERRORS_BLOCK_TOO_FAR("messages.errors.block-too-far"),
-    MESSAGES_ERRORS_POS_ALREADY_EXISTS("messages.errors.pos-already-exists"),
-    MESSAGES_ERRORS_POS_NOT_CHEST("messages.errors.pos-not-chest"),
-    MESSAGES_ERRORS_POS_DOUBLE_CHEST("messages.errors.pos-double-chest"),
-    MESSAGES_ERRORS_POS_EMPTY("messages.errors.pos-empty"),
-    MESSAGES_ERRORS_POS_INVALID_CARD("messages.errors.pos-invalid-card"),
-    MESSAGES_ERRORS_POS_NO_PERMISSION("messages.errors.pos-no-permission"),
-    MESSAGES_ERRORS_CARD_NO_PERMISSION("messages.errors.card-no-permission"),
-    MESSAGES_ERRORS_NO_CARD("messages.errors.no-card"),
-    MESSAGES_ERRORS_POS_ITEMS_CHANGED("messages.errors.pos-items-changed"),
-    MESSAGES_ERRORS_POS_CREATE_BUSINESS_ONLY("messages.errors.pos-create-business-only"),
-    MESSAGES_ERRORS_DISALLOWED_CHARACTERS("messages.errors.disallowed-characters"),
-    MESSAGES_BALANCE("messages.balance"),
-    MESSAGES_LIST_ACCOUNTS_HEADER("messages.list-accounts.header"),
-    MESSAGES_LIST_ACCOUNTS_ENTRY("messages.list-accounts.entry"),
-    MESSAGES_RELOAD("messages.reload"),
-    MESSAGES_ACCOUNT_CREATED("messages.account-created"),
-    MESSAGES_BALANCE_SET("messages.balance-set"),
-    MESSAGES_NAME_SET("messages.name-set"),
-    MESSAGES_ACCOUNT_DELETED("messages.account-deleted"),
-    MESSAGES_CONFIRM_TRANSFER("messages.confirm-transfer"),
-    MESSAGES_TRANSFER_SENT("messages.transfer-sent"),
-    MESSAGES_TRANSFER_RECEIVED("messages.transfer-received"),
-    MESSAGES_HISTORY_HEADER("messages.history.header"),
-    MESSAGES_HISTORY_ENTRY("messages.history.entry"),
-    MESSAGES_HISTORY_FOOTER("messages.history.footer"),
-    MESSAGES_HISTORY_NO_TRANSACTIONS("messages.history.no-transactions"),
-    MESSAGES_INSTRUMENT_CREATED("messages.instrument-created"),
-    MESSAGES_POS_CREATED("messages.pos-created"),
-    MESSAGES_POS_REMOVED("messages.pos-removed"),
-    MESSAGES_POS_PURCHASE("messages.pos-purchase"),
-    MESSAGES_POS_PURCHASE_SELLER("messages.pos-purchase-seller"),
-    MESSAGES_WHOIS("messages.whois"),
-    MESSAGES_UPDATE_AVAILABLE("messages.update-available");
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
-    private final @NotNull String key;
+public final class BankConfig {
+    public @NotNull FileConfiguration config;
 
-    BankConfig(@NotNull String key) {
-        this.key = key;
+    public BankConfig(@NotNull final FileConfiguration config) {
+        this.config = config;
     }
 
-    public @NotNull String getKey() {
-        return key;
+    //db.db
+    public @NotNull String dbDb() {
+        return Objects.requireNonNull(config.getString("db.db"));
+    }
+
+    // db.sqlite.file
+    public @NotNull String dbSqliteFile() {
+        return Objects.requireNonNull(config.getString("db.sqlite.file"));
+    }
+
+    // db.mariadb.jdbc
+    public @NotNull String dbMariadbJdbc() {
+        return Objects.requireNonNull(config.getString("db.mariadb.jdbc"));
+    }
+
+    // db.mariadb.user
+    public @NotNull String dbMariadbUser() {
+        return Objects.requireNonNull(config.getString("db.mariadb.user"));
+    }
+
+    // db.mariadb.password
+    public @NotNull String dbMariadbPassword() {
+        return Objects.requireNonNull(config.getString("db.mariadb.password"));
+    }
+
+    // db.cachePrepStmts
+    public boolean dbCachePrepStmts() {
+        return config.getBoolean("db.cachePrepStmts");
+    }
+
+    // db.prepStmtCacheSize
+    public int dbPrepStmtCacheSize() {
+        return config.getInt("db.prepStmtCacheSize");
+    }
+
+    // db.prepStmtCacheSqlLimit
+    public int dbPrepStmtCacheSqlLimit() {
+        return config.getInt("db.prepStmtCacheSqlLimit");
+    }
+
+    // db.useServerPrepStmts
+    public boolean dbUseServerPrepStmts() {
+        return config.getBoolean("db.useServerPrepStmts");
+    }
+
+    // db.useLocalSessionState
+    public boolean dbUseLocalSessionState() {
+        return config.getBoolean("db.useLocalSessionState");
+    }
+
+    // db.rewriteBatchedStatements
+    public boolean dbRewriteBatchedStatements() {
+        return config.getBoolean("db.rewriteBatchedStatements");
+    }
+
+    // db.cacheResultSetMetadata
+    public boolean dbCacheResultSetMetadata() {
+        return config.getBoolean("db.cacheResultSetMetadata");
+    }
+
+    // db.cacheServerConfiguration
+    public boolean dbCacheServerConfiguration() {
+        return config.getBoolean("db.cacheServerConfiguration");
+    }
+
+    // db.elideSetAutoCommits
+    public boolean dbElideSetAutoCommits() {
+        return config.getBoolean("db.elideSetAutoCommits");
+    }
+
+    // db.maintainTimeStats
+    public boolean dbMaintainTimeStats() {
+        return config.getBoolean("db.maintainTimeStats");
+    }
+
+    // currency.symbol
+    public @NotNull String currencySymbol() {
+        return Objects.requireNonNull(config.getString("currency.symbol"));
+    }
+
+    // currency.format
+    public @NotNull String currencyFormat() {
+        return Objects.requireNonNull(config.getString("currency.format"));
+    }
+
+    // starting-balance
+    public @NotNull Optional<@NotNull Double> startingBalance() {
+        if (Objects.requireNonNull(config.getString("starting-balance")).equalsIgnoreCase("null"))
+            return Optional.empty();
+        else return Optional.of(config.getDouble("starting-balance"));
+    }
+
+    // prevent-close-last-personal
+    public boolean preventCloseLastPersonal() {
+        return config.getBoolean("prevent-close-last-personal");
+    }
+
+    // server-account.enabled
+    public boolean serverAccountEnabled() {
+        return config.getBoolean("server-account.enabled");
+    }
+
+    // server-account.name
+    public @NotNull String serverAccountName() {
+        return Objects.requireNonNull(config.getString("server-account.name"));
+    }
+
+    // server-account.type
+    public @NotNull Account.Type serverAccountType() {
+        return Account.Type.getType(config.getInt("server-account.type"));
+    }
+
+    // server-account.starting-balance
+    public @NotNull Optional<@NotNull Double> serverAccountStartingBalance() {
+        if (Objects.requireNonNull(config.getString("server-account.starting-balance")).equalsIgnoreCase("infinity"))
+            return Optional.empty();
+        else return Optional.of(config.getDouble("server-account.starting-balance"));
+    }
+
+    // account-limits.
+    public int accountLimits(final @NotNull Account.Type type) {
+        return config.getInt("account-limits." + Account.Type.getType(type));
+    }
+
+    // transfer-confirmation.enabled
+    public boolean transferConfirmationEnabled() {
+        return config.getBoolean("transfer-confirmation.enabled");
+    }
+
+    // transfer-confirmation.min-amount
+    public double transferConfirmationMinAmount() {
+        return config.getDouble("transfer-confirmation.min-amount");
+    }
+
+    // transfer-confirmation.bypass-own-accounts
+    public boolean transferConfirmationBypassOwnAccounts() {
+        return config.getBoolean("transfer-confirmation.bypass-own-accounts");
+    }
+
+    // history.per-page
+    public int historyPerPage() {
+        return config.getInt("history.per-page");
+    }
+
+    // instruments.material
+    public final @NotNull Material instrumentsMaterial() {
+        return Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(config.getString("instruments.material"))));
+    }
+
+    // instruments.require-item
+    public boolean instrumentsRequireItem() {
+        return config.getBoolean("instruments.require-item");
+    }
+
+    // instruments.name
+    public @NotNull String instrumentsName() {
+        return Objects.requireNonNull(config.getString("instruments.name"));
+    }
+
+    // instruments.lore
+    public @NotNull List<@NotNull String> instrumentsLore() {
+        return Objects.requireNonNull(config.getStringList("instruments.lore"));
+    }
+
+    // instruments.glint.enabled
+    public boolean instrumentsGlintEnabled() {
+        return config.getBoolean("instruments.glint.enabled");
+    }
+
+    // instruments.glint.enchantment
+    public @NotNull Enchantment instrumentsGlintEnchantment() {
+        return Objects.requireNonNull(Enchantment.getByKey(NamespacedKey.minecraft(Objects.requireNonNull(config.getString("instruments.glint.enchantment")))));
+    }
+
+    // pos.allow-personal
+    public boolean posAllowPersonal() {
+        return config.getBoolean("pos.allow-personal");
+    }
+
+    // pos.title
+    public @NotNull String posTitle() {
+        return Objects.requireNonNull(config.getString("pos.title"));
+    }
+
+    // pos.info.material
+    public @NotNull Material posInfoMaterial() {
+        return Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(config.getString("pos.info.material"))));
+    }
+
+    // pos.info.glint
+    public boolean posInfoGlint() {
+        return config.getBoolean("pos.info.glint");
+    }
+
+    // pos.info.name-owner
+    public @NotNull String posInfoNameOwner() {
+        return Objects.requireNonNull(config.getString("pos.info.name-owner"));
+    }
+
+    // pos.info.name-buyer
+    public @NotNull String posInfoNameBuyer() {
+        return Objects.requireNonNull(config.getString("pos.info.name-buyer"));
+    }
+
+    // pos.info.lore-owner
+    public @NotNull List<@NotNull String> posInfoLoreOwner() {
+        return Objects.requireNonNull(config.getStringList("pos.info.lore-owner"));
+    }
+
+    // pos.info.lore-buyer
+    public @NotNull List<@NotNull String> posInfoLoreBuyer() {
+        return Objects.requireNonNull(config.getStringList("pos.info.lore-buyer"));
+    }
+
+    // pos.delete.material
+    public @NotNull Material posDeleteMaterial() {
+        return Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(config.getString("pos.delete.material"))));
+    }
+
+    // pos.delete.glint
+    public boolean posDeleteGlint() {
+        return config.getBoolean("pos.delete.glint");
+    }
+
+    // pos.delete.name
+    public @NotNull String posDeleteName() {
+        return Objects.requireNonNull(config.getString("pos.delete.name"));
+    }
+
+    // pos.delete.lore
+    public @NotNull List<@NotNull String> posDeleteLore() {
+        return Objects.requireNonNull(config.getStringList("pos.delete.lore"));
+    }
+
+    // pos.confirm.material
+    public @NotNull Material posConfirmMaterial() {
+        return Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(config.getString("pos.confirm.material"))));
+    }
+
+    // pos.confirm.glint
+    public boolean posConfirmGlint() {
+        return config.getBoolean("pos.confirm.glint");
+    }
+
+    // pos.confirm.name
+    public @NotNull String posConfirmName() {
+        return Objects.requireNonNull(config.getString("pos.confirm.name"));
+    }
+
+    // pos.confirm.lore
+    public @NotNull List<@NotNull String> posConfirmLore() {
+        return Objects.requireNonNull(config.getStringList("pos.confirm.lore"));
+    }
+
+    // pos.decline.material
+    public @NotNull Material posDeclineMaterial() {
+        return Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(config.getString("pos.decline.material"))));
+    }
+
+    // pos.decline.glint
+    public boolean posDeclineGlint() {
+        return config.getBoolean("pos.decline.glint");
+    }
+
+    // pos.decline.name
+    public @NotNull String posDeclineName() {
+        return Objects.requireNonNull(config.getString("pos.decline.name"));
+    }
+
+    // pos.decline.lore
+    public @NotNull List<@NotNull String> posDeclineLore() {
+        return Objects.requireNonNull(config.getStringList("pos.decline.lore"));
+    }
+
+    // messages.command-usage
+    public @NotNull String messagesCommandUsage() {
+        return Objects.requireNonNull(config.getString("messages.command-usage"));
+    }
+
+    // messages.types.
+    public @NotNull String messagesTypes(final @NotNull Account.Type type) {
+        return Objects.requireNonNull(config.getString("messages.types." + Account.Type.getType(type)));
+    }
+
+    // messages.errors.no-accounts
+    public @NotNull String messagesErrorsNoAccounts() {
+        return Objects.requireNonNull(config.getString("messages.errors.no-accounts"));
+    }
+
+    // messages.errors.no-permission
+    public @NotNull String messagesErrorsNoPermission() {
+        return Objects.requireNonNull(config.getString("messages.errors.no-permission"));
+    }
+
+    // messages.errors.account-not-found
+    public @NotNull String messagesErrorsAccountNotFound() {
+        return Objects.requireNonNull(config.getString("messages.errors.account-not-found"));
+    }
+
+    // messages.errors.unknown-command
+    public @NotNull String messagesErrorsUnknownCommand() {
+        return Objects.requireNonNull(config.getString("messages.errors.unknown-command"));
+    }
+
+    // messages.errors.max-accounts
+    public @NotNull String messagesErrorsMaxAccounts() {
+        return Objects.requireNonNull(config.getString("messages.errors.max-accounts"));
+    }
+
+    // messages.errors.rename-personal
+    public @NotNull String messagesErrorsRenamePersonal() {
+        return Objects.requireNonNull(config.getString("messages.errors.rename-personal"));
+    }
+
+    // messages.errors.not-account-owner
+    public @NotNull String messagesErrorsNotAccountOwner() {
+        return Objects.requireNonNull(config.getString("messages.errors.not-account-owner"));
+    }
+
+    // messages.errors.frozen
+    public @NotNull String messagesErrorsFrozen() {
+        return Objects.requireNonNull(config.getString("messages.errors.frozen"));
+    }
+
+    // messages.errors.same-from-to
+    public @NotNull String messagesErrorsSameFromTo() {
+        return Objects.requireNonNull(config.getString("messages.errors.same-from-to"));
+    }
+
+    // messages.errors.transfer-self-only
+    public @NotNull String messagesErrorsTransferSelfOnly() {
+        return Objects.requireNonNull(config.getString("messages.errors.transfer-self-only"));
+    }
+
+    // messages.errors.transfer-other-only
+    public @NotNull String messagesErrorsTransferOtherOnly() {
+        return Objects.requireNonNull(config.getString("messages.errors.transfer-other-only"));
+    }
+
+    // messages.errors.invalid-number
+    public @NotNull String messagesErrorsInvalidNumber() {
+        return Objects.requireNonNull(config.getString("messages.errors.invalid-number"));
+    }
+
+    // messages.errors.negative-transfer
+    public @NotNull String messagesErrorsNegativeTransfer() {
+        return Objects.requireNonNull(config.getString("messages.errors.negative-transfer"));
+    }
+
+    // messages.errors.insufficient-funds
+    public @NotNull String messagesErrorsInsufficientFunds() {
+        return Objects.requireNonNull(config.getString("messages.errors.insufficient-funds"));
+    }
+
+    // messages.errors.closing-balance
+    public @NotNull String messagesErrorsClosingBalance() {
+        return Objects.requireNonNull(config.getString("messages.errors.closing-balance"));
+    }
+
+    // messages.errors.closing-personal
+    public @NotNull String messagesErrorsClosingPersonal() {
+        return Objects.requireNonNull(config.getString("messages.errors.closing-personal"));
+    }
+
+    // messages.errors.player-only
+    public @NotNull String messagesErrorsPlayerOnly() {
+        return Objects.requireNonNull(config.getString("messages.errors.player-only"));
+    }
+
+    // messages.errors.player-not-found
+    public @NotNull String messagesErrorsPlayerNotFound() {
+        return Objects.requireNonNull(config.getString("messages.errors.player-not-found"));
+    }
+
+    // messages.errors.instrument-requires-item
+    public @NotNull String messagesErrorsInstrumentRequiresItem() {
+        return Objects.requireNonNull(config.getString("messages.errors.instrument-requires-item"));
+    }
+
+    // messages.errors.target-inventory-full
+    public @NotNull String messagesErrorsTargetInventoryFull() {
+        return Objects.requireNonNull(config.getString("messages.errors.target-inventory-full"));
+    }
+
+    // messages.errors.block-too-far
+    public @NotNull String messagesErrorsBlockTooFar() {
+        return Objects.requireNonNull(config.getString("messages.errors.block-too-far"));
+    }
+
+    // messages.errors.pos-already-exists
+    public @NotNull String messagesErrorsPosAlreadyExists() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-already-exists"));
+    }
+
+    // messages.errors.pos-not-chest
+    public @NotNull String messagesErrorsPosNotChest() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-not-chest"));
+    }
+
+    // messages.errors.pos-double-chest
+    public @NotNull String messagesErrorsPosDoubleChest() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-double-chest"));
+    }
+
+    // messages.errors.pos-empty
+    public @NotNull String messagesErrorsPosEmpty() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-empty"));
+    }
+
+    // messages.errors.pos-invalid-card
+    public @NotNull String messagesErrorsPosInvalidCard() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-invalid-card"));
+    }
+
+    // messages.errors.pos-no-permission
+    public @NotNull String messagesErrorsPosNoPermission() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-no-permission"));
+    }
+
+    // messages.errors.card-no-permission
+    public @NotNull String messagesErrorsCardNoPermission() {
+        return Objects.requireNonNull(config.getString("messages.errors.card-no-permission"));
+    }
+
+    // messages.errors.no-card
+    public @NotNull String messagesErrorsNoCard() {
+        return Objects.requireNonNull(config.getString("messages.errors.no-card"));
+    }
+
+    // messages.errors.pos-items-changed
+    public @NotNull String messagesErrorsPosItemsChanged() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-items-changed"));
+    }
+
+    // messages.errors.pos-create-business-only
+    public @NotNull String messagesErrorsPosCreateBusinessOnly() {
+        return Objects.requireNonNull(config.getString("messages.errors.pos-create-business-only"));
+    }
+
+    // messages.errors.disallowed-characters
+    public @NotNull String messagesErrorsDisallowedCharacters() {
+        return Objects.requireNonNull(config.getString("messages.errors.disallowed-characters"));
+    }
+
+    // messages.balance
+    public @NotNull String messagesBalance() {
+        return Objects.requireNonNull(config.getString("messages.balance"));
+    }
+
+    // messages.list-accounts.header
+    public @NotNull String messagesListAccountsHeader() {
+        return Objects.requireNonNull(config.getString("messages.list-accounts.header"));
+    }
+
+    // messages.list-accounts.entry
+    public @NotNull String messagesListAccountsEntry() {
+        return Objects.requireNonNull(config.getString("messages.list-accounts.entry"));
+    }
+
+    // messages.reload
+    public @NotNull String messagesReload() {
+        return Objects.requireNonNull(config.getString("messages.reload"));
+    }
+
+    // messages.account-created
+    public @NotNull String messagesAccountCreated() {
+        return Objects.requireNonNull(config.getString("messages.account-created"));
+    }
+
+    // messages.balance-set
+    public @NotNull String messagesBalanceSet() {
+        return Objects.requireNonNull(config.getString("messages.balance-set"));
+    }
+
+    // messages.name-set
+    public @NotNull String messagesNameSet() {
+        return Objects.requireNonNull(config.getString("messages.name-set"));
+    }
+
+    // messages.account-deleted
+    public @NotNull String messagesAccountDeleted() {
+        return Objects.requireNonNull(config.getString("messages.account-deleted"));
+    }
+
+    // messages.confirm-transfer
+    public @NotNull String messagesConfirmTransfer() {
+        return Objects.requireNonNull(config.getString("messages.confirm-transfer"));
+    }
+
+    // messages.transfer-sent
+    public @NotNull String messagesTransferSent() {
+        return Objects.requireNonNull(config.getString("messages.transfer-sent"));
+    }
+
+    // messages.transfer-received
+    public @NotNull String messagesTransferReceived() {
+        return Objects.requireNonNull(config.getString("messages.transfer-received"));
+    }
+
+    // messages.history.header
+    public @NotNull String messagesHistoryHeader() {
+        return Objects.requireNonNull(config.getString("messages.history.header"));
+    }
+
+    // messages.history.entry
+    public @NotNull String messagesHistoryEntry() {
+        return Objects.requireNonNull(config.getString("messages.history.entry"));
+    }
+
+    // messages.history.footer
+    public @NotNull String messagesHistoryFooter() {
+        return Objects.requireNonNull(config.getString("messages.history.footer"));
+    }
+
+    // messages.history.no-transactions
+    public @NotNull String messagesHistoryNoTransactions() {
+        return Objects.requireNonNull(config.getString("messages.history.no-transactions"));
+    }
+
+    // messages.instrument-created
+    public @NotNull String messagesInstrumentCreated() {
+        return Objects.requireNonNull(config.getString("messages.instrument-created"));
+    }
+
+    // messages.pos-removed
+    public @NotNull String messagesPosCreated() {
+        return Objects.requireNonNull(config.getString("messages.pos-created"));
+    }
+
+    // messages.pos-removed
+    public @NotNull String messagesPosRemoved() {
+        return Objects.requireNonNull(config.getString("messages.pos-removed"));
+    }
+
+    // messages.pos-purchase
+    public @NotNull String messagesPosPurchase() {
+        return Objects.requireNonNull(config.getString("messages.pos-purchase"));
+    }
+
+    // messages.pos-purchase.seller
+    public @NotNull String messagesPosPurchaseSeller() {
+        return Objects.requireNonNull(config.getString("messages.pos-purchase.seller"));
+    }
+
+    // messages.whois
+    public @NotNull String messagesWhois() {
+        return Objects.requireNonNull(config.getString("messages.whois"));
+    }
+
+    // messages.update-available
+    public @NotNull String messagesUpdateAvailable() {
+        return Objects.requireNonNull(config.getString("messages.update-available"));
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -37,18 +37,6 @@ public abstract class Command implements CommandExecutor, TabCompleter {
     }
 
     /**
-     * Send config message to sender.
-     *
-     * @param sender       Command sender.
-     * @param path         Path to message in config.
-     * @param placeholders Placeholders to replace.
-     * @return Always true.
-     */
-    public static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull BankConfig path, final @NotNull TagResolver @NotNull ... placeholders) {
-        return sendMessage(sender, Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString(path.getKey())), placeholders);
-    }
-
-    /**
      * Send command usage to sender.
      *
      * @param sender    Command sender.
@@ -57,6 +45,6 @@ public abstract class Command implements CommandExecutor, TabCompleter {
      * @return Always true.
      */
     protected static boolean sendUsage(final @NotNull CommandSender sender, final @NotNull String label, final @NotNull String arguments) {
-        return sendMessage(sender, BankConfig.MESSAGES_COMMAND_USAGE, Placeholder.unparsed("command", label), Placeholder.unparsed("arguments", arguments));
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesCommandUsage(), Placeholder.unparsed("command", label), Placeholder.unparsed("arguments", arguments));
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -9,8 +9,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
-
 public abstract class Command implements CommandExecutor, TabCompleter {
     /**
      * Send message to sender.

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -5,7 +5,6 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -292,7 +292,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.title")),
+        final @NotNull Inventory gui = Bukkit.createInventory(null, size, MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posTitle(),
                 Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                 Placeholder.unparsed("price", pos.price.toPlainString()),
                 Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
@@ -300,19 +300,19 @@ public final class POS {
         ));
         gui.addItem(items);
 
-        final @NotNull ItemStack overview = new ItemStack(Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.info.material")))), 1);
-        if (BankAccounts.getInstance().getConfig().getBoolean("pos.info.glint")) {
+        final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);
+        if (BankAccounts.getInstance().config().posInfoGlint()) {
             overview.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             overview.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
-        overviewMeta.displayName(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.info.name-owner")),
+        overviewMeta.displayName(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posInfoNameOwner(),
                 Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                 Placeholder.unparsed("price", pos.price.toPlainString()),
                 Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
                 Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
         ).decoration(TextDecoration.ITALIC, false));
-        overviewMeta.lore(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getStringList("pos.info.lore-owner")).stream()
+        overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreOwner().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(line,
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                         Placeholder.unparsed("price", pos.price.toPlainString()),
@@ -322,14 +322,14 @@ public final class POS {
         overview.setItemMeta(overviewMeta);
         gui.setItem(size - 5, overview);
 
-        final @NotNull ItemStack delete = new ItemStack(Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.delete.material")))), 1);
-        if (BankAccounts.getInstance().getConfig().getBoolean("pos.delete.glint")) {
+        final @NotNull ItemStack delete = new ItemStack(BankAccounts.getInstance().config().posDeleteMaterial(), 1);
+        if (BankAccounts.getInstance().config().posDeleteGlint()) {
             delete.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             delete.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta deleteMeta = delete.getItemMeta();
-        deleteMeta.displayName(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.delete.name"))).decoration(TextDecoration.ITALIC, false));
-        deleteMeta.lore(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getStringList("pos.delete.lore")).stream().map(line -> MiniMessage.miniMessage().deserialize(line)).collect(Collectors.toList()));
+        deleteMeta.displayName(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posDeleteName()).decoration(TextDecoration.ITALIC, false));
+        deleteMeta.lore(BankAccounts.getInstance().config().posDeleteLore().stream().map(line -> MiniMessage.miniMessage().deserialize(line)).collect(Collectors.toList()));
         final @NotNull PersistentDataContainer deleteContainer = deleteMeta.getPersistentDataContainer();
         deleteContainer.set(BankAccounts.Key.POS_OWNER_GUI, PersistentDataType.STRING, pos.id());
         delete.setItemMeta(deleteMeta);
@@ -353,7 +353,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.title")),
+        final @NotNull Inventory gui = Bukkit.createInventory(null, size, MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posTitle(),
                 Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                 Placeholder.unparsed("price", pos.price.toPlainString()),
                 Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
@@ -361,19 +361,19 @@ public final class POS {
         ));
         gui.addItem(items);
 
-        final @NotNull ItemStack overview = new ItemStack(Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.info.material")))), 1);
-        if (BankAccounts.getInstance().getConfig().getBoolean("pos.info.glint")) {
+        final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);
+        if (BankAccounts.getInstance().config().posInfoGlint()) {
             overview.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             overview.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
-        overviewMeta.displayName(MiniMessage.miniMessage().deserialize(Account.placeholdersString(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.info.name-buyer")), pos.seller),
+        overviewMeta.displayName(MiniMessage.miniMessage().deserialize(Account.placeholdersString(BankAccounts.getInstance().config().posInfoNameBuyer(), pos.seller),
                 Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                 Placeholder.unparsed("price", pos.price.toPlainString()),
                 Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
                 Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
         ).decoration(TextDecoration.ITALIC, false));
-        overviewMeta.lore(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getStringList("pos.info.lore-buyer")).stream()
+        overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreBuyer().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, pos.seller),
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                         Placeholder.unparsed("price", pos.price.toPlainString()),
@@ -385,19 +385,19 @@ public final class POS {
         overview.setItemMeta(overviewMeta);
         gui.setItem(size - 5, overview);
 
-        final @NotNull ItemStack confirm = new ItemStack(Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.confirm.material")))), 1);
-        if (BankAccounts.getInstance().getConfig().getBoolean("pos.confirm.glint")) {
+        final @NotNull ItemStack confirm = new ItemStack(BankAccounts.getInstance().config().posConfirmMaterial(), 1);
+        if (BankAccounts.getInstance().config().posConfirmGlint()) {
             confirm.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             confirm.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta confirmMeta = confirm.getItemMeta();
-        confirmMeta.displayName(MiniMessage.miniMessage().deserialize(Account.placeholdersString(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.confirm.name")), account),
+        confirmMeta.displayName(MiniMessage.miniMessage().deserialize(Account.placeholdersString(BankAccounts.getInstance().config().posConfirmName(), account),
                 Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                 Placeholder.unparsed("price", pos.price.toPlainString()),
                 Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
                 Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
         ).decoration(TextDecoration.ITALIC, false));
-        confirmMeta.lore(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getStringList("pos.confirm.lore")).stream()
+        confirmMeta.lore(BankAccounts.getInstance().config().posConfirmLore().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, account),
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                         Placeholder.unparsed("price", pos.price.toPlainString()),
@@ -409,14 +409,14 @@ public final class POS {
         confirm.setItemMeta(confirmMeta);
         gui.setItem(size - 7, confirm);
 
-        final @NotNull ItemStack cancel = new ItemStack(Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("pos.decline.material")))), 1);
-        if (BankAccounts.getInstance().getConfig().getBoolean("pos.cancel.glint")) {
+        final @NotNull ItemStack cancel = new ItemStack(BankAccounts.getInstance().config().posDeclineMaterial(), 1);
+        if (BankAccounts.getInstance().config().posDeclineGlint()) {
             cancel.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             cancel.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta cancelMeta = cancel.getItemMeta();
-        cancelMeta.displayName(MiniMessage.miniMessage().deserialize("<red><bold>Cancel Purchase</bold></red>").decoration(TextDecoration.ITALIC, false));
-        cancelMeta.lore(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getStringList("pos.decline.lore")).stream()
+        cancelMeta.displayName(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posDeclineName()).decoration(TextDecoration.ITALIC, false));
+        cancelMeta.lore(BankAccounts.getInstance().config().posDeclineLore().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, account),
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
                         Placeholder.unparsed("price", pos.price.toPlainString()),

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Permissions.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Permissions.java
@@ -1,0 +1,34 @@
+package pro.cloudnode.smp.bankaccounts;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class Permissions {
+    public static @NotNull String COMMAND = "bank.command";
+    public static @NotNull String BALANCE_SELF = "bank.balance.self";
+    public static @NotNull String TRANSFER_SELF = "bank.transfer.self";
+    public static @NotNull String TRANSFER_OTHER = "bank.transfer.other";
+    public static @NotNull String HISTORY = "bank.history";
+    public static @NotNull String ACCOUNT_CREATE = "bank.account.create";
+    public static @NotNull String INSTRUMENT_CREATE = "bank.instrument.create";
+    public static @NotNull String WHOIS = "bank.whois";
+    public static @NotNull String SET_NAME = "bank.set.name";
+    public static @NotNull String DELETE = "bank.delete";
+    public static @NotNull String POS_CREATE = "bank.pos.create";
+    public static @NotNull String POS_USE = "bank.pos.use";
+    public static @NotNull String RELOAD = "bank.reload";
+    public static @NotNull String BALANCE_OTHER = "bank.balance.other";
+    public static @NotNull String HISTORY_OTHER = "bank.history.other";
+    public static @NotNull String ACCOUNT_CREATE_OTHER = "bank.account.create.other";
+    public static @NotNull String ACCOUNT_CREATE_BYPASS = "bank.account.create.bypass";
+    public static @NotNull String INSTRUMENT_CREATE_OTHER = "bank.instrument.create.other";
+    public static @NotNull String INSTRUMENT_CREATE_BYPASS = "bank.instrument.create.bypass";
+    public static @NotNull String SET_BALANCE = "bank.set.balance";
+    public static @NotNull String SET_NAME_OTHER = "bank.set.name.other";
+    public static @NotNull String SET_NAME_PERSONAL = "b=ank.set.name.personal";
+    public static @NotNull String DELETE_OTHER = "bank.delete.other";
+    public static @NotNull String DELETE_PERSONAL = "bank.delete.personal";
+    public static @NotNull String POS_CREATE_OTHER = "bank.pos.create.other";
+    public static @NotNull String POS_CREATE_PERSONAL = "bank.pos.create.personal";
+    public static @NotNull String POS_USE_OTHER = "bank.pos.use.other";
+    public static @NotNull String NOTIFY_UPDATE = "bank.notify-update";
+}

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
-import pro.cloudnode.smp.bankaccounts.BankConfig;
 import pro.cloudnode.smp.bankaccounts.Transaction;
 
 import java.math.BigDecimal;
@@ -27,7 +26,7 @@ import java.util.stream.Collectors;
 public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
     @Override
     public boolean onCommand(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
-        if (!sender.hasPermission("bank.command")) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+        if (!sender.hasPermission("bank.command")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         return run(sender, label, args);
     }
 
@@ -162,7 +161,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             case "transactions", "history" -> transactions(sender, argsSubset, label);
             case "instrument", "card" -> instrument(sender, argsSubset, label);
             case "whois", "who", "info" -> whois(sender, argsSubset, label);
-            default -> sendMessage(sender, BankConfig.MESSAGES_ERRORS_UNKNOWN_COMMAND);
+            default -> sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsUnknownCommand());
         };
     }
 
@@ -230,39 +229,37 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
     public static boolean balance(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) throws NullPointerException {
         if (args.length == 0) {
             if (!sender.hasPermission("bank.balance.self"))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             return listAccounts(sender, BankAccounts.getOfflinePlayer(sender));
         }
         else if (args[0].equals("--player")) {
             if (!sender.hasPermission("bank.balance.other"))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             if (args.length == 1) return sendUsage(sender, label, "balance --player <player>");
             return listAccounts(sender, BankAccounts.getInstance().getServer().getOfflinePlayer(args[1]));
         }
         else {
             if (!sender.hasPermission("bank.balance.self"))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
-            if (account.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+            if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
             else if (!sender.hasPermission("bank.balance.other") && !account.get().owner.getUniqueId()
                     .equals((BankAccounts.getOfflinePlayer(sender)).getUniqueId()))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER);
-            else return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                        .getConfig().getString("messages.balance")), account.get()));
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
+            else return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBalance(), account.get()));
         }
     }
 
     private static boolean listAccounts(final @NotNull CommandSender sender, final @NotNull OfflinePlayer player) {
         final @NotNull Account @NotNull [] accounts = Account.get(player);
-        if (accounts.length == 0) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_ACCOUNTS);
+        if (accounts.length == 0) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoAccounts());
         else if (accounts.length == 1)
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString("messages.balance")), accounts[0]));
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBalance(), accounts[0]));
         else {
-            sendMessage(sender, BankConfig.MESSAGES_LIST_ACCOUNTS_HEADER);
+            sendMessage(sender, BankAccounts.getInstance().config().messagesListAccountsHeader());
             for (final @NotNull Account account : accounts)
-                sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig()
-                        .getString("messages.list-accounts.entry")), account));
+                sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().config()
+                        .messagesListAccountsEntry()), account));
         }
         return true;
     }
@@ -271,9 +268,9 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * Reload plugin configuration
      */
     public static boolean reload(final @NotNull CommandSender sender) {
-        if (!sender.hasPermission("bank.reload")) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+        if (!sender.hasPermission("bank.reload")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         BankAccounts.reload();
-        return sendMessage(sender, BankConfig.MESSAGES_RELOAD);
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesReload());
     }
 
     /**
@@ -282,11 +279,11 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      */
     public static boolean create(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
         if (!sender.hasPermission("bank.account.create"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         @NotNull OfflinePlayer target = BankAccounts.getOfflinePlayer(sender);
         if (Arrays.asList(args).contains("--player")) {
             if (!sender.hasPermission("bank.account.create.other"))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             else {
                 // find value of --player
                 int index = Arrays.asList(args).indexOf("--player");
@@ -301,25 +298,22 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         // check if target is the same as sender
         if (target.getUniqueId().equals(BankAccounts.getOfflinePlayer(sender)
                 .getUniqueId()) && !sender.hasPermission("bank.account.create"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         final @NotNull Optional<Account.Type> optionalType = Account.Type.fromString(args[0]);
         if (optionalType.isEmpty())
             return sendUsage(sender, label, "create <PERSONAL|BUSINESS> " + (sender.hasPermission("bank.account.create.other") ? "[--player <player>]" : ""));
         if (!sender.hasPermission("bank.account.create.bypass")) {
             final @NotNull Account @NotNull [] accounts = Account.get(target, optionalType.get());
-            int limit = BankAccounts.getInstance().getConfig()
-                    .getInt("account-limits." + Account.Type.getType(optionalType.get()));
+            int limit = BankAccounts.getInstance().config().accountLimits(optionalType.get());
             if (limit != -1 && accounts.length >= limit)
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_MAX_ACCOUNTS, Placeholder.unparsed("type", optionalType
-                        .get().getName()), Placeholder.unparsed("limit", String.valueOf(BankAccounts.getInstance()
-                        .getConfig().getInt("account-limits." + Account.Type.getType(optionalType.get())))));
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsMaxAccounts(), Placeholder.unparsed("type", optionalType
+                        .get().getName()), Placeholder.unparsed("limit", String.valueOf(limit)));
         }
 
         final @NotNull Account account = new Account(target, optionalType.get(), null, BigDecimal.ZERO, false);
         account.insert();
 
-        return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig()
-                .getString("messages.account-created")), account));
+        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountCreated(), account));
     }
 
     /**
@@ -328,23 +322,22 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      */
     public static boolean setBalance(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
         if (!sender.hasPermission("bank.set.balance"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 2)
             return sendUsage(sender, label, "setbalance " + (args.length > 0 ? args[0] : "<account>") + " <balance|Infinity>");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
-        if (account.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         else {
             final @Nullable BigDecimal balance;
             try {
                 balance = args[1].equalsIgnoreCase("Infinity") ? null : BigDecimal.valueOf(Double.parseDouble(args[1]));
             }
             catch (NumberFormatException e) {
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_INVALID_NUMBER, Placeholder.unparsed("number", args[1]));
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(), Placeholder.unparsed("number", args[1]));
             }
             account.get().balance = balance;
             account.get().update();
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString("messages.balance-set")), account.get()));
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBalanceSet(), account.get()));
         }
     }
 
@@ -353,28 +346,28 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      */
     public static boolean setName(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
         if (!sender.hasPermission("bank.set.name"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 2)
             return sendUsage(sender, label, "setname " + (args.length > 0 ? args[0] : "<account>") + " [name]");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
-        if (account.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         else {
             if (!sender.hasPermission("bank.set.name.other") && !account.get().owner.getUniqueId()
                     .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER);
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
             if (!sender.hasPermission("bank.set.name.personal") && account.get().type == Account.Type.PERSONAL)
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_RENAME_PERSONAL);
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsRenamePersonal());
             @Nullable String name = String.join(" ", Arrays.copyOfRange(args, 1, args.length)).trim();
             name = name.length() > 32 ? name.substring(0, 32) : name;
-            name = name.length() == 0 ? null : name;
+            name = name.isEmpty() ? null : name;
 
             if (name != null && (name.contains("<") || name.contains(">")))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_DISALLOWED_CHARACTERS, Placeholder.unparsed("characters", "<>"));
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(), Placeholder.unparsed("characters", "<>"));
 
             account.get().name = name;
             account.get().update();
             return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString("messages.name-set")), account.get()));
+                    .config().messagesNameSet()), account.get()));
         }
     }
 
@@ -382,25 +375,23 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * Delete account
      */
     public static boolean delete(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.delete")) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+        if (!sender.hasPermission("bank.delete")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 1) return sendUsage(sender, label, "delete <account>");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
-        if (account.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         if (!sender.hasPermission("bank.delete.other") && !account.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
         final @NotNull Optional<@NotNull BigDecimal> balance = Optional.ofNullable(account.get().balance);
         if (balance.isPresent() && balance.get().compareTo(BigDecimal.ZERO) != 0)
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_CLOSING_BALANCE);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsClosingBalance());
         if (account.get().frozen)
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString(BankConfig.MESSAGES_ERRORS_FROZEN.getKey())), account.get()));
-        if (BankAccounts.getInstance().getConfig()
-                .getBoolean("prevent-close-last-personal") && account.get().type == Account.Type.PERSONAL && !sender.hasPermission("bank.delete.personal") && Account.get(account.get().owner, Account.Type.PERSONAL).length == 1)
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_CLOSING_PERSONAL);
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), account.get()));
+        if (BankAccounts.getInstance().config()
+                .preventCloseLastPersonal() && account.get().type == Account.Type.PERSONAL && !sender.hasPermission("bank.delete.personal") && Account.get(account.get().owner, Account.Type.PERSONAL).length == 1)
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsClosingPersonal());
         account.get().delete();
-        return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig()
-                .getString("messages.account-deleted")), account.get()));
+        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountDeleted(), account.get()));
     }
 
     /**
@@ -410,7 +401,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      */
     public static boolean transfer(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
         if (!sender.hasPermission("bank.transfer.self") && !sender.hasPermission("bank.transfer.other"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         boolean confirm = args.length > 0 && args[0].equals("--confirm");
         @NotNull String[] argsCopy = args;
         if (confirm) argsCopy = Arrays.copyOfRange(argsCopy, 1, argsCopy.length);
@@ -418,60 +409,55 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             return sendUsage(sender, label, "transfer " + (argsCopy.length > 0 ? argsCopy[0] : "<from>") + " " + (argsCopy.length > 1 ? argsCopy[1] : "<to>") + " <amount> [description]");
         final @NotNull Optional<@NotNull Account> from = Account.get(argsCopy[0]);
         // account does not exist
-        if (from.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (from.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         // sender does not own account
         if (!from.get().owner.getUniqueId().equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
         // account is frozen
         if (from.get().frozen)
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString(BankConfig.MESSAGES_ERRORS_FROZEN.getKey())), from.get()));
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), from.get()));
         // recipient does not exist
         final @NotNull Optional<@NotNull Account> to = Account.get(argsCopy[1]);
-        if (to.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (to.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         // to is same as from
-        if (from.get().id.equals(to.get().id)) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_SAME_FROM_TO);
+        if (from.get().id.equals(to.get().id)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsSameFromTo());
         // to is frozen
         if (to.get().frozen)
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString(BankConfig.MESSAGES_ERRORS_FROZEN.getKey())), to.get()));
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), to.get()));
         // to is foreign
         if (!sender.hasPermission("bank.transfer.other") && !to.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId())) {
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_TRANSFER_SELF_ONLY);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsTransferSelfOnly());
         }
         // to is not foreign
         if (!sender.hasPermission("bank.transfer.self") && to.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_TRANSFER_OTHER_ONLY);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsTransferOtherOnly());
 
         final @NotNull BigDecimal amount;
         try {
             amount = BigDecimal.valueOf(Double.parseDouble(argsCopy[2])).setScale(2, RoundingMode.HALF_UP);
         }
         catch (NumberFormatException e) {
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_INVALID_NUMBER, Placeholder.unparsed("number", argsCopy[2]));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(), Placeholder.unparsed("number", argsCopy[2]));
         }
         // amount is 0 or less
         if (amount.compareTo(BigDecimal.ZERO) <= 0)
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NEGATIVE_TRANSFER);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNegativeTransfer());
         // account has insufficient funds
         if (!from.get().hasFunds(amount))
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString(BankConfig.MESSAGES_ERRORS_INSUFFICIENT_FUNDS.getKey())), from.get()));
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsInsufficientFunds(), from.get()));
 
         @Nullable String description = args.length > 3 ? String
                 .join(" ", Arrays.copyOfRange(argsCopy, 3, argsCopy.length)).trim() : null;
         if (description != null && description.length() > 64) description = description.substring(0, 64);
 
         if (description != null && (description.contains("<") || description.contains(">")))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_DISALLOWED_CHARACTERS, Placeholder.unparsed("characters", "<>"));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(), Placeholder.unparsed("characters", "<>"));
 
-        if (!confirm && BankAccounts.getInstance().getConfig().getBoolean("transfer-confirmation.enabled")) {
-            final @NotNull BigDecimal minAmount = BigDecimal.valueOf(BankAccounts.getInstance().getConfig()
-                    .getDouble(BankConfig.TRANSFER_CONFIRMATION_MIN_AMOUNT.getKey()));
-            boolean bypassOwnAccounts = BankAccounts.getInstance().getConfig()
-                    .getBoolean(BankConfig.TRANSFER_CONFIRMATION_BYPASS_OWN_ACCOUNTS.getKey());
+        if (!confirm && BankAccounts.getInstance().config().transferConfirmationEnabled()) {
+            final @NotNull BigDecimal minAmount = BigDecimal.valueOf(BankAccounts.getInstance().config().transferConfirmationMinAmount());
+            boolean bypassOwnAccounts = BankAccounts.getInstance().config().transferConfirmationBypassOwnAccounts();
             if (amount.compareTo(minAmount) >= 0 && (!bypassOwnAccounts || !from.get().owner.getUniqueId()
                     .equals(to.get().owner.getUniqueId()))) {
                 return sendMessage(sender, transferConfirmation(from.get(), to.get(), amount, description));
@@ -479,13 +465,11 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         }
 
         final @NotNull Transaction transfer = from.get().transfer(to.get(), amount, description, null);
-        sendMessage(sender, Transaction.placeholders(transfer, Objects.requireNonNull(BankAccounts.getInstance()
-                .getConfig().getString(BankConfig.MESSAGES_TRANSFER_SENT.getKey()))));
+        sendMessage(sender, Transaction.placeholders(transfer, BankAccounts.getInstance().config().messagesTransferSent()));
         final @NotNull Optional<@NotNull Player> player = Optional.ofNullable(to.get().owner.getPlayer());
         if (player.isPresent() && player.get().isOnline() && !player.get().getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
-            sendMessage(player.get(), Transaction.placeholders(transfer, Objects.requireNonNull(BankAccounts
-                    .getInstance().getConfig().getString(BankConfig.MESSAGES_TRANSFER_RECEIVED.getKey()))));
+            sendMessage(player.get(), Transaction.placeholders(transfer, BankAccounts.getInstance().config().messagesTransferReceived()));
 
         return true;
     }
@@ -496,16 +480,15 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * {@code transactions <account> [page|--all]}
      */
     public static boolean transactions(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.history")) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+        if (!sender.hasPermission("bank.history")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 1) return sendUsage(sender, label, "transactions <account> [page=1|--all]");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
-        if (account.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         if (!sender.hasPermission("bank.history.other") && !account.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
         final int page;
-        @NotNull Optional<@NotNull Integer> limit = Optional.of(BankAccounts.getInstance().getConfig()
-                .getInt(BankConfig.HISTORY_PER_PAGE.getKey()));
+        @NotNull Optional<@NotNull Integer> limit = Optional.of(BankAccounts.getInstance().config().historyPerPage());
         if (args.length > 1) {
             if (args[1].equals("--all")) {
                 page = 1;
@@ -517,7 +500,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
                     if (page <= 0) throw new NumberFormatException();
                 }
                 catch (final @NotNull NumberFormatException e) {
-                    return sendMessage(sender, BankConfig.MESSAGES_ERRORS_INVALID_NUMBER, Placeholder.unparsed("number", args[1]));
+                    return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(), Placeholder.unparsed("number", args[1]));
                 }
             }
         }
@@ -525,17 +508,14 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         final @NotNull Transaction @NotNull [] transactions = limit
                 .map(integer -> Transaction.get(account.get(), integer, page))
                 .orElseGet(() -> Transaction.get(account.get()));
-        if (transactions.length == 0) sendMessage(sender, BankConfig.MESSAGES_HISTORY_NO_TRANSACTIONS);
+        if (transactions.length == 0) sendMessage(sender, BankAccounts.getInstance().config().messagesHistoryNoTransactions());
         else {
             final int count = Transaction.count(account.get());
             final int maxPage = (int) Math.ceil((double) count / limit.orElse(count));
-            transactionsHeaderFooter(sender, account.get(), page, maxPage, Objects.requireNonNull(BankAccounts
-                    .getInstance().getConfig().getString(BankConfig.MESSAGES_HISTORY_HEADER.getKey())));
+            transactionsHeaderFooter(sender, account.get(), page, maxPage, BankAccounts.getInstance().config().messagesHistoryHeader());
             for (final @NotNull Transaction transaction : transactions)
-                sendMessage(sender, Transaction.historyPlaceholders(transaction, account.get(), Objects.requireNonNull(BankAccounts
-                        .getInstance().getConfig().getString(BankConfig.MESSAGES_HISTORY_ENTRY.getKey()))));
-            transactionsHeaderFooter(sender, account.get(), page, maxPage, Objects.requireNonNull(BankAccounts
-                    .getInstance().getConfig().getString(BankConfig.MESSAGES_HISTORY_FOOTER.getKey())));
+                sendMessage(sender, Transaction.historyPlaceholders(transaction, account.get(), BankAccounts.getInstance().config().messagesHistoryEntry()));
+            transactionsHeaderFooter(sender, account.get(), page, maxPage, BankAccounts.getInstance().config().messagesHistoryFooter());
         }
         return true;
     }
@@ -545,10 +525,10 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      */
     public static boolean instrument(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
         if (!sender.hasPermission("bank.instrument.create"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (!(sender instanceof Player)) {
             if (!sender.hasPermission("bank.instrument.create.other"))
-                return sendMessage(sender, BankConfig.MESSAGES_ERRORS_PLAYER_ONLY);
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPlayerOnly());
             else if (args.length < 2)
                 return sendUsage(sender, label, "instrument " + (args.length > 0 ? args[0] : "<account>") + " <player>");
         }
@@ -557,28 +537,24 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         final @Nullable Player target = !(sender instanceof final @NotNull Player player) || (sender.hasPermission("bank.instrument.create.other") && args.length >= 2) ? BankAccounts
                 .getInstance().getServer().getPlayer(args[1]) : player;
         if (target == null || !target.isOnline())
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_PLAYER_NOT_FOUND);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPlayerNotFound());
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
-        if (account.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         if (!sender.hasPermission("bank.instrument.create.other") && !account.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
 
         if (target.getInventory().firstEmpty() == -1)
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_TARGET_INVENTORY_FULL, Placeholder.unparsed("player", target.getName()));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsTargetInventoryFull(), Placeholder.unparsed("player", target.getName()));
 
-        if (BankAccounts.getInstance().getConfig()
-                .getBoolean(BankConfig.INSTRUMENTS_REQUIRE_ITEM.getKey()) && sender instanceof final @NotNull Player player) {
-            final @NotNull Material material = Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts
-                    .getInstance().getConfig().getString(BankConfig.INSTRUMENTS_MATERIAL.getKey()))));
+        if (BankAccounts.getInstance().config().instrumentsRequireItem() && sender instanceof final @NotNull Player player) {
+            final @NotNull Material material = BankAccounts.getInstance().config().instrumentsMaterial();
             final ItemStack item = Arrays.stream(player.getInventory().getStorageContents())
                     .filter(itemStack -> itemStack != null && itemStack.getType() == material && !itemStack.hasItemMeta())
                     .findFirst().orElse(null);
 
             if (!sender.hasPermission("bank.instrument.create.bypass")) {
-                if (item == null) return sendMessage(sender, Objects
-                        .requireNonNull(BankAccounts.getInstance().getConfig()
-                                .getString(BankConfig.MESSAGES_ERRORS_INSTRUMENT_REQUIRES_ITEM.getKey()))
+                if (item == null) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInstrumentRequiresItem()
                         .replace("<material-key>", material.translationKey()), Placeholder.unparsed("material", material.name()));
                 else {
                     final @NotNull ItemStack clone = item.clone();
@@ -589,20 +565,19 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         }
 
         target.getInventory().addItem(account.get().createInstrument());
-        return sendMessage(sender, BankConfig.MESSAGES_INSTRUMENT_CREATED);
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesInstrumentCreated());
     }
 
     /**
      * Account whois
      */
     public static boolean whois(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.whois")) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+        if (!sender.hasPermission("bank.whois")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 1) return sendUsage(sender, label, "whois <account>");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         return account
-                .map(value -> sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                        .getConfig().getString(BankConfig.MESSAGES_WHOIS.getKey())), value)))
-                .orElseGet(() -> sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND));
+                .map(value -> sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesWhois(), value)))
+                .orElseGet(() -> sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound()));
     }
 
     /**
@@ -638,7 +613,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      */
     public static @NotNull Component transferConfirmation(final @NotNull Account from, final @NotNull Account to, final @NotNull BigDecimal amount, final @Nullable String description) {
         return Account.placeholders(Objects
-                .requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.confirm-transfer"))
+                .requireNonNull(BankAccounts.getInstance().config().messagesConfirmTransfer())
                 .replace("<amount>", amount.toPlainString())
                 .replace("<amount-formatted>", BankAccounts.formatCurrency(amount))
                 .replace("<amount-short>", BankAccounts.formatCurrencyShort(amount))

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
+import pro.cloudnode.smp.bankaccounts.Permissions;
 import pro.cloudnode.smp.bankaccounts.Transaction;
 
 import java.math.BigDecimal;
@@ -26,36 +27,36 @@ import java.util.stream.Collectors;
 public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
     @Override
     public boolean onCommand(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
-        if (!sender.hasPermission("bank.command")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
+        if (!sender.hasPermission(Permissions.COMMAND)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         return run(sender, label, args);
     }
 
     @Override
     public @NotNull ArrayList<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
         final @NotNull ArrayList<@NotNull String> suggestions = new ArrayList<>();
-        if (!sender.hasPermission("bank.command")) return suggestions;
+        if (!sender.hasPermission(Permissions.COMMAND)) return suggestions;
         if (args.length == 1) {
             suggestions.add("help");
-            if (sender.hasPermission("bank.balance.self"))
+            if (sender.hasPermission(Permissions.BALANCE_SELF))
                 suggestions.addAll(Arrays.asList("balance", "bal", "account", "accounts"));
-            if (sender.hasPermission("bank.reload")) suggestions.add("reload");
-            if (sender.hasPermission("bank.account.create")) suggestions.addAll(Arrays.asList("create", "new"));
-            if (sender.hasPermission("bank.set.balance")) suggestions.addAll(Arrays.asList("setbal", "setbalance"));
-            if (sender.hasPermission("bank.set.name")) suggestions.addAll(Arrays.asList("setname", "rename"));
-            if (sender.hasPermission("bank.delete")) suggestions.add("delete");
-            if (sender.hasPermission("bank.transfer.self") || sender.hasPermission("bank.transfer.other"))
+            if (sender.hasPermission(Permissions.RELOAD)) suggestions.add("reload");
+            if (sender.hasPermission(Permissions.ACCOUNT_CREATE)) suggestions.addAll(Arrays.asList("create", "new"));
+            if (sender.hasPermission(Permissions.SET_BALANCE)) suggestions.addAll(Arrays.asList("setbal", "setbalance"));
+            if (sender.hasPermission(Permissions.SET_NAME)) suggestions.addAll(Arrays.asList("setname", "rename"));
+            if (sender.hasPermission(Permissions.DELETE)) suggestions.add("delete");
+            if (sender.hasPermission(Permissions.TRANSFER_SELF) || sender.hasPermission(Permissions.TRANSFER_OTHER))
                 suggestions.addAll(Arrays.asList("transfer", "send", "pay"));
-            if (sender.hasPermission("bank.history")) suggestions.addAll(Arrays.asList("transactions", "history"));
-            if (sender.hasPermission("bank.instrument.create")) suggestions.addAll(Arrays.asList("instrument", "card"));
-            if (sender.hasPermission("bank.whois")) suggestions.addAll(Arrays.asList("whois", "who", "info"));
+            if (sender.hasPermission(Permissions.HISTORY)) suggestions.addAll(Arrays.asList("transactions", "history"));
+            if (sender.hasPermission(Permissions.INSTRUMENT_CREATE)) suggestions.addAll(Arrays.asList("instrument", "card"));
+            if (sender.hasPermission(Permissions.WHOIS)) suggestions.addAll(Arrays.asList("whois", "who", "info"));
         }
         else {
             switch (args[0]) {
                 case "balance", "bal", "account", "accounts" -> {
-                    if (!sender.hasPermission("bank.balance.self") && !sender.hasPermission("bank.balance.other"))
+                    if (!sender.hasPermission(Permissions.BALANCE_SELF) && !sender.hasPermission(Permissions.BALANCE_OTHER))
                         return suggestions;
                     if (args.length == 2) {
-                        if (sender.hasPermission("bank.balance.other")) suggestions.add("--player");
+                        if (sender.hasPermission(Permissions.BALANCE_OTHER)) suggestions.add("--player");
                         if (sender instanceof OfflinePlayer player) {
                             final @NotNull Account @NotNull [] accounts = Account.get(player);
                             for (Account account : accounts) suggestions.add(account.id);
@@ -65,23 +66,23 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
                             for (final @NotNull Account account : accounts) suggestions.add(account.id);
                         }
                     }
-                    else if (args.length == 3 && args[1].equals("--player") && sender.hasPermission("bank.balance.other"))
+                    else if (args.length == 3 && args[1].equals("--player") && sender.hasPermission(Permissions.BALANCE_OTHER))
                         suggestions.addAll(Arrays.stream(Account.get()).map(account -> account.owner.getName())
                                 .filter(Objects::nonNull).collect(Collectors.toSet()));
                 }
                 case "create", "new" -> {
-                    if (!sender.hasPermission("bank.account.create")) return suggestions;
+                    if (!sender.hasPermission(Permissions.ACCOUNT_CREATE)) return suggestions;
                     if (args.length == 2) {
                         suggestions.addAll(Arrays.asList("PERSONAL", "BUSINESS"));
                     }
-                    else if (args.length == 3 && sender.hasPermission("bank.account.create.other"))
+                    else if (args.length == 3 && sender.hasPermission(Permissions.ACCOUNT_CREATE_OTHER))
                         suggestions.add("--player");
-                    else if (args.length == 4 && args[2].equals("--player") && sender.hasPermission("bank.account.create.other"))
+                    else if (args.length == 4 && args[2].equals("--player") && sender.hasPermission(Permissions.ACCOUNT_CREATE_OTHER))
                         suggestions.addAll(Arrays.stream(Account.get()).map(account -> account.owner.getName())
                                 .filter(Objects::nonNull).collect(Collectors.toSet()));
                 }
                 case "setbal", "setbalance" -> {
-                    if (!sender.hasPermission("bank.set.balance")) return suggestions;
+                    if (!sender.hasPermission(Permissions.SET_BALANCE)) return suggestions;
                     if (args.length == 2) {
                         final @NotNull Account @NotNull [] accounts = Account.get();
                         for (final @NotNull Account account : accounts) suggestions.add(account.id);
@@ -89,51 +90,51 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
                     if (args.length == 3) suggestions.add("Infinity");
                 }
                 case "setname", "rename" -> {
-                    if (!sender.hasPermission("bank.set.name")) return suggestions;
+                    if (!sender.hasPermission(Permissions.SET_NAME)) return suggestions;
                     if (args.length == 2) {
-                        final @NotNull Account @NotNull [] accounts = sender.hasPermission("bank.set.name.other") ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
+                        final @NotNull Account @NotNull [] accounts = sender.hasPermission(Permissions.SET_NAME_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
                         for (final @NotNull Account account : accounts) suggestions.add(account.id);
                     }
                 }
                 case "delete" -> {
-                    if (!sender.hasPermission("bank.delete")) return suggestions;
+                    if (!sender.hasPermission(Permissions.DELETE)) return suggestions;
                     if (args.length == 2) suggestions.addAll(Arrays
-                            .stream(sender.hasPermission("bank.delete.other") ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender)))
-                            .filter(account -> sender.hasPermission("bank.delete.person") || account.type != Account.Type.PERSONAL)
+                            .stream(sender.hasPermission(Permissions.DELETE_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender)))
+                            .filter(account -> sender.hasPermission(Permissions.DELETE_PERSONAL) || account.type != Account.Type.PERSONAL)
                             .map(account -> account.id).collect(Collectors.toSet()));
                 }
                 case "transfer", "send", "pay" -> {
-                    if (!sender.hasPermission("bank.transfer.self") && !sender.hasPermission("bank.transfer.other"))
+                    if (!sender.hasPermission(Permissions.TRANSFER_SELF) && !sender.hasPermission(Permissions.TRANSFER_OTHER))
                         return suggestions;
                     if (args.length == 2) {
                         final @NotNull Account @NotNull [] accounts = Account.get(BankAccounts.getOfflinePlayer(sender));
                         for (final @NotNull Account account : accounts) suggestions.add(account.id);
                     }
                     else if (args.length == 3) suggestions.addAll(Arrays
-                            .stream(sender.hasPermission("bank.transfer.other") ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender)))
+                            .stream(sender.hasPermission(Permissions.TRANSFER_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender)))
                             .filter(account -> !account.id.equals(args[1])).map(account -> account.id)
                             .collect(Collectors.toSet()));
                 }
                 case "transactions", "history" -> {
-                    if (!sender.hasPermission("bank.history")) return suggestions;
+                    if (!sender.hasPermission(Permissions.HISTORY)) return suggestions;
                     if (args.length == 2) {
-                        final @NotNull Account @NotNull [] accounts = sender.hasPermission("bank.history.other") ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
+                        final @NotNull Account @NotNull [] accounts = sender.hasPermission(Permissions.HISTORY_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
                         for (final @NotNull Account account : accounts) suggestions.add(account.id);
                     }
                     else if (args.length == 3) suggestions.add("--all");
                 }
                 case "instrument", "card" -> {
-                    if (!sender.hasPermission("bank.instrument.create")) return suggestions;
+                    if (!sender.hasPermission(Permissions.INSTRUMENT_CREATE)) return suggestions;
                     if (args.length == 2) {
-                        final @NotNull Account @NotNull [] accounts = sender.hasPermission("bank.instrument.create.other") ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
+                        final @NotNull Account @NotNull [] accounts = sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
                         for (final @NotNull Account account : accounts) suggestions.add(account.id);
                     }
-                    else if (args.length == 3 && sender.hasPermission("bank.instrument.create.other"))
+                    else if (args.length == 3 && sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER))
                         suggestions.addAll(BankAccounts.getInstance().getServer().getOnlinePlayers().stream()
                                 .map(Player::getName).toList());
                 }
                 case "whois", "who", "info" -> {
-                    if (!sender.hasPermission("bank.whois")) return suggestions;
+                    if (!sender.hasPermission(Permissions.WHOIS)) return suggestions;
                     if (args.length == 2)
                         suggestions.addAll(Arrays.stream(Account.get()).map(account -> account.id).toList());
                 }
@@ -182,31 +183,31 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         sendMessage(sender, "<dark_gray>---</dark_gray>");
         sendMessage(sender, "<green>Available commands:");
         sendMessage(sender, "");
-        if (sender.hasPermission("bank.balance.self"))
+        if (sender.hasPermission(Permissions.BALANCE_SELF))
             sendMessage(sender, "<click:suggest_command:/bank balance ><green>/bank balance <gray>[account]</gray></green> <white>- Check your accounts</click>");
-        if (sender.hasPermission("bank.balance.other"))
+        if (sender.hasPermission(Permissions.BALANCE_OTHER))
             sendMessage(sender, "<click:suggest_command:/bank balance --player ><green>/bank balance <gray>--player <player></gray></green> <white>- List another player's accounts</click>");
-        if (sender.hasPermission("bank.transfer.self") || sender.hasPermission("bank.transfer.other"))
+        if (sender.hasPermission(Permissions.TRANSFER_SELF) || sender.hasPermission(Permissions.TRANSFER_OTHER))
             sendMessage(sender, "<click:suggest_command:/bank transfer ><green>/bank transfer <gray><from> <to> <amount> [description]</gray></green> <white>- Transfer money to another account</click>");
-        if (sender.hasPermission("bank.history"))
+        if (sender.hasPermission(Permissions.HISTORY))
             sendMessage(sender, "<click:suggest_command:/bank transactions ><green>/bank transactions <gray><account> [page=1]</gray></green> <white>- List transactions</click>");
-        if (sender.hasPermission("bank.account.create"))
+        if (sender.hasPermission(Permissions.ACCOUNT_CREATE))
             sendMessage(sender, "<click:suggest_command:/bank create ><green>/bank create <gray><PERSONAL|BUSINESS></gray></green> <white>- Create a new account</click>");
-        if (sender.hasPermission("bank.account.create.other"))
+        if (sender.hasPermission(Permissions.ACCOUNT_CREATE_OTHER))
             sendMessage(sender, "<click:suggest_command:/bank create ><green>/bank create <gray><PERSONAL|BUSINESS> --player <player></gray></green> <white>- Create an account for another player</click>");
-        if (sender.hasPermission("bank.delete"))
+        if (sender.hasPermission(Permissions.DELETE))
             sendMessage(sender, "<click:suggest_command:/bank delete ><green>/bank delete <gray><account></gray></green> <white>- Delete an account</click>");
-        if (sender.hasPermission("bank.instrument.create"))
-            sendMessage(sender, "<click:suggest_command:/bank instrument ><green>/bank instrument <gray><account>" + (sender.hasPermission("bank.instrument.create.other") ? " [player]" : "") + "</gray></green> <white>- Create a new instrument</click>");
-        if (sender.hasPermission("bank.whois"))
+        if (sender.hasPermission(Permissions.INSTRUMENT_CREATE))
+            sendMessage(sender, "<click:suggest_command:/bank instrument ><green>/bank instrument <gray><account>" + (sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER) ? " [player]" : "") + "</gray></green> <white>- Create a new instrument</click>");
+        if (sender.hasPermission(Permissions.WHOIS))
             sendMessage(sender, "<click:suggest_command:/bank whois ><green>/bank whois <gray><account></gray></green> <white>- Get information about an account</click>");
-        if (sender.hasPermission("bank.pos.create"))
+        if (sender.hasPermission(Permissions.POS_CREATE))
             sendMessage(sender, "<click:suggest_command:/pos ><green>/pos <gray><account> <price> [description]</gray></green> <white>- Create a new point of sale</click>");
-        if (sender.hasPermission("bank.set.balance"))
+        if (sender.hasPermission(Permissions.SET_BALANCE))
             sendMessage(sender, "<click:suggest_command:/bank setbalance ><green>/bank setbalance <gray><account> <balance|Infinity></gray></green> <white>- Set an account's balance</click>");
-        if (sender.hasPermission("bank.set.name"))
+        if (sender.hasPermission(Permissions.SET_NAME))
             sendMessage(sender, "<click:suggest_command:/bank setname ><green>/bank setname <gray><account> [name]</gray></green> <white>- Set an account's name</click>");
-        if (sender.hasPermission("bank.reload"))
+        if (sender.hasPermission(Permissions.RELOAD))
             sendMessage(sender, "<click:suggest_command:/bank reload><green>/bank reload</green> <white>- Reload plugin configuration</click>");
         return sendMessage(sender, "<dark_gray>---</dark_gray>");
     }
@@ -228,22 +229,22 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      */
     public static boolean balance(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) throws NullPointerException {
         if (args.length == 0) {
-            if (!sender.hasPermission("bank.balance.self"))
+            if (!sender.hasPermission(Permissions.BALANCE_SELF))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             return listAccounts(sender, BankAccounts.getOfflinePlayer(sender));
         }
         else if (args[0].equals("--player")) {
-            if (!sender.hasPermission("bank.balance.other"))
+            if (!sender.hasPermission(Permissions.BALANCE_OTHER))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             if (args.length == 1) return sendUsage(sender, label, "balance --player <player>");
             return listAccounts(sender, BankAccounts.getInstance().getServer().getOfflinePlayer(args[1]));
         }
         else {
-            if (!sender.hasPermission("bank.balance.self"))
+            if (!sender.hasPermission(Permissions.BALANCE_SELF))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
             if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
-            else if (!sender.hasPermission("bank.balance.other") && !account.get().owner.getUniqueId()
+            else if (!sender.hasPermission(Permissions.BALANCE_OTHER) && !account.get().owner.getUniqueId()
                     .equals((BankAccounts.getOfflinePlayer(sender)).getUniqueId()))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
             else return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBalance(), account.get()));
@@ -268,7 +269,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * Reload plugin configuration
      */
     public static boolean reload(final @NotNull CommandSender sender) {
-        if (!sender.hasPermission("bank.reload")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
+        if (!sender.hasPermission(Permissions.RELOAD)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         BankAccounts.reload();
         return sendMessage(sender, BankAccounts.getInstance().config().messagesReload());
     }
@@ -278,11 +279,11 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * create [type] [--player <player>]
      */
     public static boolean create(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.account.create"))
+        if (!sender.hasPermission(Permissions.ACCOUNT_CREATE))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         @NotNull OfflinePlayer target = BankAccounts.getOfflinePlayer(sender);
         if (Arrays.asList(args).contains("--player")) {
-            if (!sender.hasPermission("bank.account.create.other"))
+            if (!sender.hasPermission(Permissions.ACCOUNT_CREATE_OTHER))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
             else {
                 // find value of --player
@@ -294,15 +295,15 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             }
         }
         if (args.length == 0)
-            return sendUsage(sender, label, "create <PERSONAL|BUSINESS> " + (sender.hasPermission("bank.account.create.other") ? "[--player <player>]" : ""));
+            return sendUsage(sender, label, "create <PERSONAL|BUSINESS> " + (sender.hasPermission(Permissions.ACCOUNT_CREATE_OTHER) ? "[--player <player>]" : ""));
         // check if target is the same as sender
         if (target.getUniqueId().equals(BankAccounts.getOfflinePlayer(sender)
-                .getUniqueId()) && !sender.hasPermission("bank.account.create"))
+                .getUniqueId()) && !sender.hasPermission(Permissions.ACCOUNT_CREATE))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         final @NotNull Optional<Account.Type> optionalType = Account.Type.fromString(args[0]);
         if (optionalType.isEmpty())
-            return sendUsage(sender, label, "create <PERSONAL|BUSINESS> " + (sender.hasPermission("bank.account.create.other") ? "[--player <player>]" : ""));
-        if (!sender.hasPermission("bank.account.create.bypass")) {
+            return sendUsage(sender, label, "create <PERSONAL|BUSINESS> " + (sender.hasPermission(Permissions.ACCOUNT_CREATE_OTHER) ? "[--player <player>]" : ""));
+        if (!sender.hasPermission(Permissions.ACCOUNT_CREATE_BYPASS)) {
             final @NotNull Account @NotNull [] accounts = Account.get(target, optionalType.get());
             int limit = BankAccounts.getInstance().config().accountLimits(optionalType.get());
             if (limit != -1 && accounts.length >= limit)
@@ -321,7 +322,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * setbal <account> <bal>
      */
     public static boolean setBalance(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.set.balance"))
+        if (!sender.hasPermission(Permissions.SET_BALANCE))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 2)
             return sendUsage(sender, label, "setbalance " + (args.length > 0 ? args[0] : "<account>") + " <balance|Infinity>");
@@ -345,17 +346,17 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * Set account name
      */
     public static boolean setName(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.set.name"))
+        if (!sender.hasPermission(Permissions.SET_NAME))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 2)
             return sendUsage(sender, label, "setname " + (args.length > 0 ? args[0] : "<account>") + " [name]");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
         else {
-            if (!sender.hasPermission("bank.set.name.other") && !account.get().owner.getUniqueId()
+            if (!sender.hasPermission(Permissions.SET_NAME_OTHER) && !account.get().owner.getUniqueId()
                     .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
-            if (!sender.hasPermission("bank.set.name.personal") && account.get().type == Account.Type.PERSONAL)
+            if (!sender.hasPermission(Permissions.SET_NAME_PERSONAL) && account.get().type == Account.Type.PERSONAL)
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsRenamePersonal());
             @Nullable String name = String.join(" ", Arrays.copyOfRange(args, 1, args.length)).trim();
             name = name.length() > 32 ? name.substring(0, 32) : name;
@@ -375,11 +376,11 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * Delete account
      */
     public static boolean delete(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.delete")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
+        if (!sender.hasPermission(Permissions.DELETE)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 1) return sendUsage(sender, label, "delete <account>");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
-        if (!sender.hasPermission("bank.delete.other") && !account.get().owner.getUniqueId()
+        if (!sender.hasPermission(Permissions.DELETE_OTHER) && !account.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
         final @NotNull Optional<@NotNull BigDecimal> balance = Optional.ofNullable(account.get().balance);
@@ -388,7 +389,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         if (account.get().frozen)
             return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), account.get()));
         if (BankAccounts.getInstance().config()
-                .preventCloseLastPersonal() && account.get().type == Account.Type.PERSONAL && !sender.hasPermission("bank.delete.personal") && Account.get(account.get().owner, Account.Type.PERSONAL).length == 1)
+                .preventCloseLastPersonal() && account.get().type == Account.Type.PERSONAL && !sender.hasPermission(Permissions.DELETE_PERSONAL) && Account.get(account.get().owner, Account.Type.PERSONAL).length == 1)
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsClosingPersonal());
         account.get().delete();
         return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountDeleted(), account.get()));
@@ -400,7 +401,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * {@code transfer [--confirm] <from> <to> <amount> [description]}
      */
     public static boolean transfer(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.transfer.self") && !sender.hasPermission("bank.transfer.other"))
+        if (!sender.hasPermission(Permissions.TRANSFER_SELF) && !sender.hasPermission(Permissions.TRANSFER_OTHER))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         boolean confirm = args.length > 0 && args[0].equals("--confirm");
         @NotNull String[] argsCopy = args;
@@ -425,12 +426,12 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         if (to.get().frozen)
             return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), to.get()));
         // to is foreign
-        if (!sender.hasPermission("bank.transfer.other") && !to.get().owner.getUniqueId()
+        if (!sender.hasPermission(Permissions.TRANSFER_OTHER) && !to.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId())) {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsTransferSelfOnly());
         }
         // to is not foreign
-        if (!sender.hasPermission("bank.transfer.self") && to.get().owner.getUniqueId()
+        if (!sender.hasPermission(Permissions.TRANSFER_SELF) && to.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsTransferOtherOnly());
 
@@ -480,11 +481,11 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * {@code transactions <account> [page|--all]}
      */
     public static boolean transactions(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.history")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
+        if (!sender.hasPermission(Permissions.HISTORY)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 1) return sendUsage(sender, label, "transactions <account> [page=1|--all]");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
-        if (!sender.hasPermission("bank.history.other") && !account.get().owner.getUniqueId()
+        if (!sender.hasPermission(Permissions.HISTORY_OTHER) && !account.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
         final int page;
@@ -524,23 +525,23 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * Create instrument
      */
     public static boolean instrument(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.instrument.create"))
+        if (!sender.hasPermission(Permissions.INSTRUMENT_CREATE))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (!(sender instanceof Player)) {
-            if (!sender.hasPermission("bank.instrument.create.other"))
+            if (!sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPlayerOnly());
             else if (args.length < 2)
                 return sendUsage(sender, label, "instrument " + (args.length > 0 ? args[0] : "<account>") + " <player>");
         }
         else if (args.length < 1)
-            return sendUsage(sender, label, "instrument <account>" + (sender.hasPermission("bank.instrument.create.other") ? " <player>" : ""));
-        final @Nullable Player target = !(sender instanceof final @NotNull Player player) || (sender.hasPermission("bank.instrument.create.other") && args.length >= 2) ? BankAccounts
+            return sendUsage(sender, label, "instrument <account>" + (sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER) ? " <player>" : ""));
+        final @Nullable Player target = !(sender instanceof final @NotNull Player player) || (sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER) && args.length >= 2) ? BankAccounts
                 .getInstance().getServer().getPlayer(args[1]) : player;
         if (target == null || !target.isOnline())
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPlayerNotFound());
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
-        if (!sender.hasPermission("bank.instrument.create.other") && !account.get().owner.getUniqueId()
+        if (!sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER) && !account.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
 
@@ -553,7 +554,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
                     .filter(itemStack -> itemStack != null && itemStack.getType() == material && !itemStack.hasItemMeta())
                     .findFirst().orElse(null);
 
-            if (!sender.hasPermission("bank.instrument.create.bypass")) {
+            if (!sender.hasPermission(Permissions.INSTRUMENT_CREATE_BYPASS)) {
                 if (item == null) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInstrumentRequiresItem()
                         .replace("<material-key>", material.translationKey()), Placeholder.unparsed("material", material.name()));
                 else {
@@ -572,7 +573,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
      * Account whois
      */
     public static boolean whois(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
-        if (!sender.hasPermission("bank.whois")) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
+        if (!sender.hasPermission(Permissions.WHOIS)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
         if (args.length < 1) return sendUsage(sender, label, "whois <account>");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         return account

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -35,59 +35,56 @@ public final class POSCommand extends pro.cloudnode.smp.bankaccounts.Command {
     @Override
     public boolean onCommand(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
         if (!(sender instanceof final @NotNull Player player))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_PLAYER_ONLY);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPlayerOnly());
         if (!player.hasPermission("bank.pos.create"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NO_PERMISSION);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
 
         if (args.length < 2)
             return sendUsage(sender, label, (args.length > 0 ? args[0] : "<account>") + " <price> [description]");
 
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
-        if (account.isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_ACCOUNT_NOT_FOUND);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
 
-        if (account.get().type == Account.Type.PERSONAL && !BankAccounts.getInstance().getConfig()
-                .getBoolean("pos.allow-personal") && !player.hasPermission("bank.pos.create.personal"))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_POS_CREATE_BUSINESS_ONLY);
+        if (account.get().type == Account.Type.PERSONAL && !BankAccounts.getInstance().config().posAllowPersonal() && !player.hasPermission("bank.pos.create.personal"))
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosCreateBusinessOnly());
 
         if (account.get().frozen)
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .getConfig().getString(BankConfig.MESSAGES_ERRORS_FROZEN.getKey())), account.get()));
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), account.get()));
 
         if (!player.hasPermission("bank.pos.create.other") && !account.get().owner.equals(player))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
 
         final @NotNull BigDecimal price;
         try {
             price = BigDecimal.valueOf(Double.parseDouble(args[1])).setScale(2, RoundingMode.HALF_UP);
         }
         catch (final @NotNull NumberFormatException e) {
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_INVALID_NUMBER, Placeholder.unparsed("number", args[1]));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(), Placeholder.unparsed("number", args[1]));
         }
 
         if (price.compareTo(BigDecimal.ZERO) <= 0)
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_INVALID_NUMBER, Placeholder.unparsed("number", args[1]));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(), Placeholder.unparsed("number", args[1]));
 
 
         final @Nullable Block target = player.getTargetBlockExact(5);
-        if (target == null) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_BLOCK_TOO_FAR);
+        if (target == null) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsBlockTooFar());
 
         if (!(target.getState() instanceof final @NotNull Chest chest))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_POS_NOT_CHEST);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosNotChest());
         if (chest.getInventory() instanceof DoubleChestInventory)
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_POS_DOUBLE_CHEST);
-        if (chest.getInventory().isEmpty()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_POS_EMPTY);
-        if (POS.get(chest).isPresent()) return sendMessage(sender, BankConfig.MESSAGES_ERRORS_POS_ALREADY_EXISTS);
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosDoubleChest());
+        if (chest.getInventory().isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosEmpty());
+        if (POS.get(chest).isPresent()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosAlreadyExists());
 
         @Nullable String description = args.length > 2 ? String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : null;
         if (description != null && description.length() > 64) description = description.substring(0, 64);
 
         if (description != null && (description.contains("<") || description.contains(">")))
-            return sendMessage(sender, BankConfig.MESSAGES_ERRORS_DISALLOWED_CHARACTERS, Placeholder.unparsed("characters", "<>"));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(), Placeholder.unparsed("characters", "<>"));
 
         final @NotNull POS pos = new POS(target.getLocation(), price, description, account.get(), new Date());
         pos.save();
-        return sendMessage(sender, replacePlaceholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig()
-                .getString("messages.pos-created")), pos));
+        return sendMessage(sender, replacePlaceholders(BankAccounts.getInstance().config().messagesPosCreated(), pos));
     }
 
     public @NotNull ArrayList<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
@@ -95,8 +92,7 @@ public final class POSCommand extends pro.cloudnode.smp.bankaccounts.Command {
         if (sender.hasPermission("bank.pos.create") && sender instanceof Player && args.length == 1) {
             final @NotNull Account[] accounts = sender.hasPermission("bank.pos.create.other") ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
             for (final @NotNull Account account : accounts) {
-                if (account.frozen || (account.type == Account.Type.PERSONAL && !BankAccounts.getInstance().getConfig()
-                        .getBoolean("pos.allow-personal") && !sender.hasPermission("bank.pos.create.personal")))
+                if (account.frozen || (account.type == Account.Type.PERSONAL && !BankAccounts.getInstance().config().posAllowPersonal() && !sender.hasPermission("bank.pos.create.personal")))
                     continue;
                 suggestions.add(account.id);
             }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
 import pro.cloudnode.smp.bankaccounts.POS;
+import pro.cloudnode.smp.bankaccounts.Permissions;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -33,7 +34,7 @@ public final class POSCommand extends pro.cloudnode.smp.bankaccounts.Command {
     public boolean onCommand(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
         if (!(sender instanceof final @NotNull Player player))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPlayerOnly());
-        if (!player.hasPermission("bank.pos.create"))
+        if (!player.hasPermission(Permissions.POS_CREATE))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
 
         if (args.length < 2)
@@ -42,13 +43,13 @@ public final class POSCommand extends pro.cloudnode.smp.bankaccounts.Command {
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
 
-        if (account.get().type == Account.Type.PERSONAL && !BankAccounts.getInstance().config().posAllowPersonal() && !player.hasPermission("bank.pos.create.personal"))
+        if (account.get().type == Account.Type.PERSONAL && !BankAccounts.getInstance().config().posAllowPersonal() && !player.hasPermission(Permissions.POS_CREATE_PERSONAL))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosCreateBusinessOnly());
 
         if (account.get().frozen)
             return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), account.get()));
 
-        if (!player.hasPermission("bank.pos.create.other") && !account.get().owner.equals(player))
+        if (!player.hasPermission(Permissions.POS_CREATE_OTHER) && !account.get().owner.equals(player))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
 
         final @NotNull BigDecimal price;
@@ -86,10 +87,10 @@ public final class POSCommand extends pro.cloudnode.smp.bankaccounts.Command {
 
     public @NotNull ArrayList<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
         final @NotNull ArrayList<@NotNull String> suggestions = new ArrayList<>();
-        if (sender.hasPermission("bank.pos.create") && sender instanceof Player && args.length == 1) {
-            final @NotNull Account[] accounts = sender.hasPermission("bank.pos.create.other") ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
+        if (sender.hasPermission(Permissions.POS_CREATE) && sender instanceof Player && args.length == 1) {
+            final @NotNull Account[] accounts = sender.hasPermission(Permissions.POS_CREATE_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
             for (final @NotNull Account account : accounts) {
-                if (account.frozen || (account.type == Account.Type.PERSONAL && !BankAccounts.getInstance().config().posAllowPersonal() && !sender.hasPermission("bank.pos.create.personal")))
+                if (account.frozen || (account.type == Account.Type.PERSONAL && !BankAccounts.getInstance().config().posAllowPersonal() && !sender.hasPermission(Permissions.POS_CREATE_PERSONAL)))
                     continue;
                 suggestions.add(account.id);
             }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -2,7 +2,6 @@ package pro.cloudnode.smp.bankaccounts.commands;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.command.Command;
@@ -13,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
-import pro.cloudnode.smp.bankaccounts.BankConfig;
 import pro.cloudnode.smp.bankaccounts.POS;
 
 import java.math.BigDecimal;
@@ -21,7 +19,6 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Objects;
 import java.util.Optional;
 
 /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
@@ -26,7 +26,7 @@ public final class BlockBreak implements Listener {
                     final @NotNull Optional<POS> pos = POS.get(chest);
                     if (pos.isPresent()) {
                         pos.get().delete();
-                        event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(pro.cloudnode.smp.bankaccounts.BankAccounts.getInstance().getConfig().getString("messages.pos-removed"))));
+                        event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesPosRemoved()));
                     }
                 });
             }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
 import pro.cloudnode.smp.bankaccounts.POS;
 
-import java.util.Objects;
 import java.util.Optional;
 
 public final class BlockBreak implements Listener {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -57,7 +57,7 @@ public class GUI implements Listener {
                 }
                 if (event.getCurrentItem() != null && event.getCurrentItem().equals(item)) {
                     pos.get().delete();
-                    event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.pos-removed"))));
+                    event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesPosRemoved()));
                     inventory.close();
                 }
             }
@@ -85,9 +85,9 @@ public class GUI implements Listener {
                 Block block = pos.get().getBlock();
                 if (!(block.getState() instanceof final @NotNull Chest chest)) {
                     inventory.close();
-                    event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.pos-empty"))));
+                    event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosEmpty()));
                     final @Nullable Player seller = pos.get().seller.owner.getPlayer();
-                    if (seller != null) seller.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.pos-empty"))));
+                    if (seller != null) seller.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosEmpty()));
                     pos.get().delete();
                     return;
                 }
@@ -100,35 +100,36 @@ public class GUI implements Listener {
                 if (item.equals(confirm)) {
                     if (!POS.verifyChecksum(chestItems, checksums)) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.pos-items-changed"))));
+                        event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosItemsChanged()));
                         final @Nullable Player seller = pos.get().seller.owner.getPlayer();
-                        if (seller != null) seller.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.pos-items-changed"))));
+                        if (seller != null) seller.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosItemsChanged()));
                         pos.get().delete();
                         return;
                     }
                     if (pos.get().seller.frozen) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.frozen")), pos.get().seller));
+                        event.getWhoClicked().sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), pos.get().seller));
                         final @Nullable Player seller = pos.get().seller.owner.getPlayer();
                         if (seller != null) {
-                            seller.sendMessage(Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.frozen")), pos.get().seller));
-                            seller.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.pos-removed"))));
+                            seller.sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), pos.get().seller));
+                            seller.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesPosRemoved()));
                         }
+                        pos.get().delete();
                         return;
                     }
                     if (buyer.get().frozen) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.frozen")), buyer.get()));
+                        event.getWhoClicked().sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), buyer.get()));
                         return;
                     }
                     if (!buyer.get().hasFunds(pos.get().price)) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.insufficient-funds")), buyer.get()));
+                        event.getWhoClicked().sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsInsufficientFunds(), buyer.get()));
                         return;
                     }
                     if (event.getWhoClicked().getInventory().getSize() - event.getWhoClicked().getInventory().getStorageContents().length < items.length) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.errors.target-inventory-full")),
+                        event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsTargetInventoryFull(),
                                 Placeholder.unparsed("player", event.getWhoClicked().getName())
                         ));
                         return;
@@ -139,13 +140,13 @@ public class GUI implements Listener {
                     event.getWhoClicked().getInventory().addItem(chestItems);
                     pos.get().delete();
                     final @NotNull String itemsFormatted = chestItems.length == 1 ? "1 item" : chestItems.length + " items";
-                    event.getWhoClicked().sendMessage(Transaction.placeholders(transaction, Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.pos-purchase"))
+                    event.getWhoClicked().sendMessage(Transaction.placeholders(transaction, BankAccounts.getInstance().config().messagesPosPurchase()
                             .replace("<items>", String.valueOf(chestItems.length))
                             .replace("<items-formatted>", itemsFormatted)
                     ));
                     final @Nullable Player seller = pos.get().seller.owner.getPlayer();
                     if (seller != null)
-                        seller.sendMessage(Transaction.placeholders(transaction, Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString("messages.pos-purchase-seller"))
+                        seller.sendMessage(Transaction.placeholders(transaction, BankAccounts.getInstance().config().messagesPosPurchaseSeller()
                                 .replace("<items>", String.valueOf(chestItems.length))
                                 .replace("<items-formatted>", itemsFormatted)
                         ));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -21,7 +21,6 @@ import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
 import pro.cloudnode.smp.bankaccounts.POS;
 import pro.cloudnode.smp.bankaccounts.Transaction;
-import pro.cloudnode.smp.bankaccounts.commands.BankCommand;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
 import pro.cloudnode.smp.bankaccounts.Command;
+import pro.cloudnode.smp.bankaccounts.Permissions;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -26,7 +27,7 @@ public final class Join implements Listener {
                         new Account(player, Account.Type.PERSONAL, null, BigDecimal.valueOf(aDouble), false).insert();
                     }
                 }));
-        if (player.hasPermission("bank.notify-update")) {
+        if (player.hasPermission(Permissions.NOTIFY_UPDATE)) {
             BankAccounts.getInstance().getServer().getScheduler().runTaskLater(BankAccounts.getInstance(), () -> {
                 BankAccounts.checkForUpdates().ifPresent(latestVersion -> {
                     Command.sendMessage(player, BankAccounts.getInstance().config().messagesUpdateAvailable()

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
@@ -6,22 +6,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
-import pro.cloudnode.smp.bankaccounts.BankConfig;
 import pro.cloudnode.smp.bankaccounts.Command;
 
 import java.math.BigDecimal;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public final class Join implements Listener {
     @EventHandler

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
@@ -35,20 +35,20 @@ public final class PlayerInteract implements Listener {
                     return;
                 }
                 if (!player.hasPermission("bank.pos.use")) {
-                    player.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString(BankConfig.MESSAGES_ERRORS_POS_NO_PERMISSION.getKey()))));
+                    player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosNoPermission()));
                     return;
                 }
                 final @NotNull ItemStack heldItem = player.getInventory().getItemInMainHand();
-                if (heldItem.getType() != Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString(BankConfig.INSTRUMENTS_MATERIAL.getKey()))))) {
-                    player.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString(BankConfig.MESSAGES_ERRORS_NO_CARD.getKey()))));
+                if (heldItem.getType() != BankAccounts.getInstance().config().instrumentsMaterial()) {
+                    player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsNoCard()));
                     return;
                 }
                 final @NotNull Optional<@NotNull Account> account = Account.get(heldItem);
                 if (account.isEmpty())
-                    player.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString(BankConfig.MESSAGES_ERRORS_POS_INVALID_CARD.getKey()))));
+                    player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosInvalidCard()));
                 else {
                     if (!player.hasPermission("bank.pos.use.other") && !account.get().owner.getUniqueId().equals(player.getUniqueId())) {
-                        player.sendMessage(MiniMessage.miniMessage().deserialize(Objects.requireNonNull(BankAccounts.getInstance().getConfig().getString(BankConfig.MESSAGES_ERRORS_NOT_ACCOUNT_OWNER.getKey()))));
+                        player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsNotAccountOwner()));
                         return;
                     }
                     POS.openBuyGui(player, chest, pos.get(), account.get());

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
 import pro.cloudnode.smp.bankaccounts.POS;
+import pro.cloudnode.smp.bankaccounts.Permissions;
 
 import java.util.Optional;
 
@@ -31,7 +32,7 @@ public final class PlayerInteract implements Listener {
                     POS.openOwnerGui(player, chest, pos.get());
                     return;
                 }
-                if (!player.hasPermission("bank.pos.use")) {
+                if (!player.hasPermission(Permissions.POS_USE)) {
                     player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosNoPermission()));
                     return;
                 }
@@ -44,7 +45,7 @@ public final class PlayerInteract implements Listener {
                 if (account.isEmpty())
                     player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosInvalidCard()));
                 else {
-                    if (!player.hasPermission("bank.pos.use.other") && !account.get().owner.getUniqueId().equals(player.getUniqueId())) {
+                    if (!player.hasPermission(Permissions.POS_USE_OTHER) && !account.get().owner.getUniqueId().equals(player.getUniqueId())) {
                         player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsNotAccountOwner()));
                         return;
                     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
@@ -1,7 +1,6 @@
 package pro.cloudnode.smp.bankaccounts.events;
 
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
@@ -14,10 +13,8 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
-import pro.cloudnode.smp.bankaccounts.BankConfig;
 import pro.cloudnode.smp.bankaccounts.POS;
 
-import java.util.Objects;
 import java.util.Optional;
 
 public final class PlayerInteract implements Listener {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -289,7 +289,6 @@ messages:
         pos-empty: "<red>(!) The chest is empty. POS cancelled.</red>"
         pos-invalid-card: "<red>(!) You need a valid bank card to use POS.</red>"
         pos-no-permission: "<red>(!) You do not have permission to use POS.</red>"
-        card-no-permission: "<red>(!) You cannot use your card here.</red>"
         no-card: "<red>(!) You must hold your bank card to use this.</red>"
         pos-items-changed: "<red>(!) The items in the chest have changed. POS cancelled.</red>"
         pos-create-business-only: "<red>(!) You can only create a POS with a business account.</red>"


### PR DESCRIPTION
Passing arbitrary strings for config keys and permissions is bound to cause mistakes (in fact it has and I had to fix a few).

This PR creates methods for accessing config properties, as well as an enum-like class with all permissions.

Supersedes #59 