### PR TITLE
Add interest rates

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -279,6 +279,16 @@ public class Account {
     }
 
     /**
+     * Get the server account
+     */
+    public static @NotNull Optional<@NotNull Account> getServerAccount() {
+        if (!BankAccounts.getInstance().config().serverAccountEnabled()) return Optional.empty();
+        final @NotNull Account @NotNull [] accounts = get(BankAccounts.getConsoleOfflinePlayer());
+        if (accounts.length == 0) return Optional.empty();
+        return Optional.of(accounts[0]);
+    }
+
+    /**
      * Insert into database
      */
     public void insert() {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -199,6 +199,22 @@ public final class BankAccounts extends JavaPlugin {
         }
     }
 
+    private void interestPayment(final @NotNull Account account, final @NotNull BigDecimal amount, final double rate, final @NotNull Account serverAccount) {
+        if (account.balance == null) return;
+        final @NotNull String description = this.config().interestDescription(account.type)
+                .replace("<rate>", String.valueOf(rate))
+                .replace("<rate-formatted>", new DecimalFormat("#.##").format(rate * 100) + "%")
+                .replace("<balance>", account.balance.toPlainString())
+                .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance));
+
+        // interest paid to the bank
+        if (rate < 0) account.transfer(serverAccount, amount, description, null);
+
+        // interest paid to the owner
+        else serverAccount.transfer(account, amount, description, null);
+    }
+
     /**
      * Get instance of the plugin
      */

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -249,11 +249,14 @@ public final class BankAccounts extends JavaPlugin {
                 .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
                 .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance));
 
-        // interest paid to the bank
-        if (rate < 0) account.transfer(serverAccount, amount, description, null);
+        try {
+            // interest paid to the bank
+            if (rate < 0) account.transfer(serverAccount, amount, description, null);
 
-        // interest paid to the owner
-        else serverAccount.transfer(account, amount, description, null);
+            // interest paid to the owner
+            else serverAccount.transfer(account, amount, description, null);
+        }
+        catch (@NotNull Exception ignored) {}
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -242,6 +242,7 @@ public final class BankAccounts extends JavaPlugin {
 
     private void interestPayment(final @NotNull Account account, final @NotNull BigDecimal amount, final double rate, final @NotNull Account serverAccount) {
         if (account.balance == null) return;
+        if (account.id.equals(serverAccount.id)) return;
         final @NotNull String description = this.config().interestDescription(account.type)
                 .replace("<rate>", String.valueOf(rate))
                 .replace("<rate-formatted>", new DecimalFormat("#.##").format(rate) + "%")

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -244,7 +244,7 @@ public final class BankAccounts extends JavaPlugin {
         if (account.balance == null) return;
         final @NotNull String description = this.config().interestDescription(account.type)
                 .replace("<rate>", String.valueOf(rate))
-                .replace("<rate-formatted>", new DecimalFormat("#.##").format(rate * 100) + "%")
+                .replace("<rate-formatted>", new DecimalFormat("#.##").format(rate) + "%")
                 .replace("<balance>", account.balance.toPlainString())
                 .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
                 .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -215,7 +215,7 @@ public final class BankAccounts extends JavaPlugin {
             final int personalInterval = config().interestInterval(Account.Type.PERSONAL);
             final double businessRate = config().interestRate(Account.Type.BUSINESS);
             final int businessInterval = config().interestInterval(Account.Type.BUSINESS);
-            if ((personalInterval <= 0 && businessInterval <= 0) || (personalRate != 0 && businessRate != 0)) return;
+            if ((personalInterval <= 0 && businessInterval <= 0) || (personalRate == 0 && businessRate == 0)) return;
             final @NotNull Optional<@NotNull Account> serverAccount = Account.getServerAccount();
             if (serverAccount.isEmpty() || serverAccount.get().frozen) return;
             final @NotNull Account @NotNull [] accounts = Arrays.stream(Account.get()).filter(account -> !account.frozen && account.balance != null && account.balance.compareTo(BigDecimal.ZERO) > 0).toArray(Account[]::new);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -291,6 +291,21 @@ public final class BankConfig {
         return Objects.requireNonNull(config.getStringList("pos.decline.lore"));
     }
 
+    // interest.*.rate
+    public double interestRate(final @NotNull Account.Type type) {
+        return config.getDouble("interest." + Account.Type.getType(type) + ".rate");
+    }
+
+    // interest.*.interval
+    public int interestInterval(final @NotNull Account.Type type) {
+        return config.getInt("interest." + Account.Type.getType(type) + ".interval");
+    }
+
+    // interest.*.description
+    public @NotNull String interestDescription(final @NotNull Account.Type type) {
+        return Objects.requireNonNull(config.getString("interest." + Account.Type.getType(type) + ".description"));
+    }
+
     // messages.command-usage
     public @NotNull String messagesCommandUsage() {
         return Objects.requireNonNull(config.getString("messages.command-usage"));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -235,7 +235,7 @@ interest:
         interval: 1440
         # Description shown in the transaction history
         # Available placeholders:
-        # - <rate> - Interest rate as decimal (e.g. "0.05")
+        # - <rate> - Interest rate as decimal (e.g. "5")
         # - <rate-formatted> - Formatted interest rate (e.g. "5%")
         # - <balance> - Account balance before interest (e.g. "123456.78")
         # - <balance-formatted> - Formatted balance before interest (e.g. "$123,456.78")

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -160,8 +160,8 @@ pos:
     # Placeholders:
     # <description> - POS description
     # <price> - Price of the POS contents without formatting, example: 123456.78
-    # <price-formatted> - Price of the POS contents with formatting, example: 123,456.78
-    # <price-short> - Price of the POS contents with formatting, example: 123k
+    # <price-formatted> - Price of the POS contents with formatting, example: $123,456.78
+    # <price-short> - Price of the POS contents with formatting, example: $123k
     title: "<green><bold>Point of Sale</bold></green> <gray>— <price-formatted></gray>"
 
     # POS info item
@@ -303,8 +303,8 @@ messages:
     # <account-type> - Account type (Personal or Business)
     # <account-owner> - Account owner username
     # <balance> - Account balance without formatting, example: 123456.78
-    # <balance-formatted> - Account balance with formatting, example: 123,456.78
-    # <balance-short> - Account balance with formatting, example: 123k
+    # <balance-formatted> - Account balance with formatting, example: $123,456.78
+    # <balance-short> - Account balance with formatting, example: $123k
     balance: |-
         <green><account></green> <gray>(<account-type> account)</gray>
         <green>Balance:</green> <white><balance-formatted></white>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -56,6 +56,7 @@ prevent-close-last-personal: true
 # Server account
 server-account:
     # If enabled, when the plugin is loaded an account will be created as player with UUID 00000000-0000-0000-0000-000000000000
+    # This is required for features like interest to work.
     enabled: true
     # Display name for the server account
     name: Central Bank
@@ -220,6 +221,31 @@ pos:
         lore:
             - "<gray>Click to decline this purchase.</gray>"
 
+# Interest rate
+# Interest is paid from/to the server account.
+# If the server account has insufficient funds, interest payments will silently fail.
+# NOTE: A transaction is created for each interest payment.
+interest:
+    # Personal accounts
+    0:
+        # Percent to add to the balance. If negative, it will be subtracted. Set to 0 to disable interest.
+        rate: 0
+        # Interval time in real-life MINUTES for how often interest is added.
+        # Default: 24 hours (i.e. midnight every day).
+        interval: 1440
+        # Description shown in the transaction history
+        # Available placeholders:
+        # - <rate> - Interest rate as decimal (e.g. "0.05")
+        # - <rate-formatted> - Formatted interest rate (e.g. "5%")
+        # - <balance> - Account balance before interest (e.g. "123456.78")
+        # - <balance-formatted> - Formatted balance before interest (e.g. "$123,456.78")
+        # - <balance-short> - Formatted balance before interest (e.g. "$123k")
+        description: "Interest payment (<rate-formatted>)"
+    # Business accounts
+    1:
+        rate: 0
+        interval: 1440
+        description: "Interest payment (<rate-formatted>)"
 
 # Messages
 messages:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -229,6 +229,7 @@ interest:
     # Personal accounts
     0:
         # Percent to add to the balance. If negative, it will be subtracted. Set to 0 to disable interest.
+        # Acceptable range: -100–100
         rate: 0
         # Interval time in real-life MINUTES for how often interest is added.
         # Default: 24 hours (i.e. midnight every day).


### PR DESCRIPTION
This PR implements interest payments.

A configurable percentage can be added or removed on all accounts at a configurable interval.

> [!Caution]
> If the server or plugin is rebooted/reloaded in the same minute interest payments are made, then they will be repeated. This is normally very unlikely.
>
> To avoid scheduling reboots at the same time as interest payments, you can calculate when interest payments are run using this formula:
> ```
> currentMinutes % interval == 0
> ```
> Where `currentMinutes` is [Unix time (Wikipedia)](https://en.wikipedia.org/wiki/Unix_time) but in minutes (divided by 60). And `interval` is the interval you have set in the config.