### PR TITLE
Add command to freeze (and unfreeze) bank accounts

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -456,6 +456,16 @@ public final class BankConfig {
         return Objects.requireNonNull(config.getString("messages.errors.disallowed-characters"));
     }
 
+    // messages.errors.already-frozen
+    public @NotNull String messagesErrorsAlreadyFrozen() {
+        return Objects.requireNonNull(config.getString("messages.errors.already-frozen"));
+    }
+
+    // messages.errors.not-frozen
+    public @NotNull String messagesErrorsNotFrozen() {
+        return Objects.requireNonNull(config.getString("messages.errors.not-frozen"));
+    }
+
     // messages.balance
     public @NotNull String messagesBalance() {
         return Objects.requireNonNull(config.getString("messages.balance"));
@@ -489,6 +499,16 @@ public final class BankConfig {
     // messages.name-set
     public @NotNull String messagesNameSet() {
         return Objects.requireNonNull(config.getString("messages.name-set"));
+    }
+
+    // messages.account-frozen
+    public @NotNull String messagesAccountFrozen() {
+        return Objects.requireNonNull(config.getString("messages.account-frozen"));
+    }
+
+    // messages.account-unfrozen
+    public @NotNull String messagesAccountUnfrozen() {
+        return Objects.requireNonNull(config.getString("messages.account-unfrozen"));
     }
 
     // messages.account-deleted

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Permissions.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Permissions.java
@@ -12,6 +12,7 @@ public final class Permissions {
     public static @NotNull String INSTRUMENT_CREATE = "bank.instrument.create";
     public static @NotNull String WHOIS = "bank.whois";
     public static @NotNull String SET_NAME = "bank.set.name";
+    public static @NotNull String FREEZE = "bank.freeze";
     public static @NotNull String DELETE = "bank.delete";
     public static @NotNull String POS_CREATE = "bank.pos.create";
     public static @NotNull String POS_USE = "bank.pos.use";
@@ -25,6 +26,7 @@ public final class Permissions {
     public static @NotNull String SET_BALANCE = "bank.set.balance";
     public static @NotNull String SET_NAME_OTHER = "bank.set.name.other";
     public static @NotNull String SET_NAME_PERSONAL = "b=ank.set.name.personal";
+    public static @NotNull String FREEZE_OTHER = "bank.freeze.other";
     public static @NotNull String DELETE_OTHER = "bank.delete.other";
     public static @NotNull String DELETE_PERSONAL = "bank.delete.personal";
     public static @NotNull String POS_CREATE_OTHER = "bank.pos.create.other";

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -385,7 +385,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
         final @NotNull Optional<@NotNull BigDecimal> balance = Optional.ofNullable(account.get().balance);
         if (balance.isPresent() && balance.get().compareTo(BigDecimal.ZERO) != 0)
-            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsClosingBalance());
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsClosingBalance(), account.get()));
         if (account.get().frozen)
             return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), account.get()));
         if (BankAccounts.getInstance().config()

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -43,6 +43,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             if (sender.hasPermission(Permissions.ACCOUNT_CREATE)) suggestions.addAll(Arrays.asList("create", "new"));
             if (sender.hasPermission(Permissions.SET_BALANCE)) suggestions.addAll(Arrays.asList("setbal", "setbalance"));
             if (sender.hasPermission(Permissions.SET_NAME)) suggestions.addAll(Arrays.asList("setname", "rename"));
+            if (sender.hasPermission(Permissions.FREEZE)) suggestions.addAll(Arrays.asList("freeze", "disable", "block", "unfreeze", "enable", "unblock"));
             if (sender.hasPermission(Permissions.DELETE)) suggestions.add("delete");
             if (sender.hasPermission(Permissions.TRANSFER_SELF) || sender.hasPermission(Permissions.TRANSFER_OTHER))
                 suggestions.addAll(Arrays.asList("transfer", "send", "pay"));
@@ -95,6 +96,12 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
                         final @NotNull Account @NotNull [] accounts = sender.hasPermission(Permissions.SET_NAME_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender));
                         for (final @NotNull Account account : accounts) suggestions.add(account.id);
                     }
+                }
+                case "freeze", "disable", "block", "unfreeze", "enable", "unblock" -> {
+                    if (!sender.hasPermission(Permissions.FREEZE)) return suggestions;
+                    if (args.length == 2) suggestions.addAll(Arrays
+                            .stream(sender.hasPermission(Permissions.FREEZE_OTHER) ? Account.get() : Account.get(BankAccounts.getOfflinePlayer(sender)))
+                            .map(account -> account.id).collect(Collectors.toSet()));
                 }
                 case "delete" -> {
                     if (!sender.hasPermission(Permissions.DELETE)) return suggestions;
@@ -157,6 +164,8 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             case "create", "new" -> create(sender, argsSubset, label);
             case "setbal", "setbalance" -> setBalance(sender, argsSubset, label);
             case "setname", "rename" -> setName(sender, argsSubset, label);
+            case "freeze", "disable", "block" -> freeze(sender, argsSubset, label);
+            case "unfreeze", "enable", "unblock" -> unfreeze(sender, argsSubset, label);
             case "delete" -> delete(sender, argsSubset, label);
             case "transfer", "send", "pay" -> transfer(sender, argsSubset, label);
             case "transactions", "history" -> transactions(sender, argsSubset, label);
@@ -195,6 +204,10 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             sendMessage(sender, "<click:suggest_command:/bank create ><green>/bank create <gray><PERSONAL|BUSINESS></gray></green> <white>- Create a new account</click>");
         if (sender.hasPermission(Permissions.ACCOUNT_CREATE_OTHER))
             sendMessage(sender, "<click:suggest_command:/bank create ><green>/bank create <gray><PERSONAL|BUSINESS> --player <player></gray></green> <white>- Create an account for another player</click>");
+        if (sender.hasPermission(Permissions.FREEZE)) {
+            sendMessage(sender, "<click:suggest_command:/bank freeze ><green>/bank freeze <gray><account></gray></green> <white>- Freeze an account</click>");
+            sendMessage(sender, "<click:suggest_command:/bank unfreeze ><green>/bank unfreeze <gray><account></gray></green> <white>- Unfreeze an account</click>");
+        }
         if (sender.hasPermission(Permissions.DELETE))
             sendMessage(sender, "<click:suggest_command:/bank delete ><green>/bank delete <gray><account></gray></green> <white>- Delete an account</click>");
         if (sender.hasPermission(Permissions.INSTRUMENT_CREATE))
@@ -370,6 +383,36 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
                     .config().messagesNameSet()), account.get()));
         }
+    }
+
+    public static boolean freeze(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
+        if (!sender.hasPermission(Permissions.FREEZE)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
+        if (args.length < 1) return sendUsage(sender, label, "freeze <account>");
+        final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
+        if (!sender.hasPermission(Permissions.FREEZE_OTHER) && !account.get().owner.getUniqueId()
+                .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
+        if (account.get().frozen)
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsAlreadyFrozen(), account.get()));
+        account.get().frozen = true;
+        account.get().update();
+        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountFrozen(), account.get()));
+    }
+
+    public static boolean unfreeze(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
+        if (!sender.hasPermission(Permissions.FREEZE)) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoPermission());
+        if (args.length < 1) return sendUsage(sender, label, "unfreeze <account>");
+        final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
+        if (account.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound());
+        if (!sender.hasPermission(Permissions.FREEZE_OTHER) && !account.get().owner.getUniqueId()
+                .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
+        if (!account.get().frozen)
+            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsNotFrozen(), account.get()));
+        account.get().frozen = false;
+        account.get().update();
+        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountUnfrozen(), account.get()));
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -295,6 +295,10 @@ messages:
         # Provided string includes disallowed characters
         # Placeholder: <characters> - the disallowed characters
         disallowed-characters: "<red>(!) The provided string contains disallowed characters: <gray><characters></gray></red>"
+        # Account is already frozen (placeholders same as balance)
+        already-frozen: "<yellow>(!) This account is already frozen.</yellow>"
+        # Account is not frozen (placeholders same as balance)
+        not-frozen: "<gold>(!) This account is not frozen.</gold>"
 
     # Account balance
     # Available placeholders:
@@ -328,6 +332,12 @@ messages:
 
     # Account name set (same placeholders as balance)
     name-set: "<green>(!) Successfully renamed account <white><account></white>"
+
+    # Account has been successfully frozen (same placeholders as balance)
+    account-frozen: "<aqua>(!) Successfully frozen account <white><account></white>"
+
+    # Account has been successfully unfrozen (same placeholders as balance)
+    account-unfrozen: "<green>(!) Successfully unfrozen account <white><account></white>"
 
     # Account deleted (same placeholders as balance)
     account-deleted: "<green>(!) Successfully deleted account <white><account></white>"


### PR DESCRIPTION
Frozen accounts cannot make & receive payments, create POS, be deleted, etc.

## Commands
`/bank freeze <account>` - freeze an account
`/bank unfreeze <account>` - unfreeze an account

## Permissions
`bank.freeze` - allow freezing and unfreezing your own accounts
`bank.freeze.other` - allow freezing and unfreezing others' accounts (`bank.freeze` also required)