### PR TITLE
Baltop leaderboard

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -279,6 +279,42 @@ public class Account {
     }
 
     /**
+     * Get accounts sorted by balance
+     *
+     * @param limit Max number of accounts to return. If not set, all accounts are returned
+     * @param page Page number starting from 1. Defaults to 1.
+     * @param type If set, only accounts of this type are returned
+     */
+    public static @NotNull Account @NotNull [] getTopBalance(final @Nullable Integer limit, final @Nullable Integer page, final @Nullable Type type) {
+        final @NotNull List<@NotNull Account> accounts = new ArrayList<>();
+        final @NotNull String query;
+        final int offset = (page != null ? page - 1 : 0) * (limit != null ? limit : 0);
+        if (type == null) query = "SELECT * FROM `bank_accounts` WHERE `balance` IS NOT NULL ORDER BY `balance` DESC" + (limit != null ? " LIMIT ? OFFSET ?" : "");
+        else query = "SELECT * FROM `bank_accounts` WHERE `balance` IS NOT NULL AND `type` = ? ORDER BY `balance` DESC" + (limit != null ? " LIMIT ? OFFSET ?" : "");
+        try (final @NotNull Connection conn = BankAccounts.getInstance().getDb().getConnection();
+             final @NotNull PreparedStatement stmt = conn.prepareStatement(query)) {
+            if (type != null) {
+                stmt.setInt(1, Type.getType(type));
+                if (limit != null) {
+                    stmt.setInt(2, limit);
+                    stmt.setInt(3, offset);
+                }
+            }
+            else if (limit != null) {
+                stmt.setInt(1, limit);
+                stmt.setInt(2, offset);
+            }
+            final @NotNull ResultSet rs = stmt.executeQuery();
+            while (rs.next()) accounts.add(new Account(rs));
+            return accounts.toArray(new Account[0]);
+        }
+        catch (final @NotNull Exception e) {
+            BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not get top balance accounts", e);
+            return new Account[0];
+        }
+    }
+
+    /**
      * Insert into database
      */
     public void insert() {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -289,8 +289,8 @@ public class Account {
         final @NotNull List<@NotNull Account> accounts = new ArrayList<>();
         final @NotNull String query;
         final int offset = (page != null ? page - 1 : 0) * (limit != null ? limit : 0);
-        if (type == null) query = "SELECT * FROM `bank_accounts` WHERE `balance` IS NOT NULL ORDER BY `balance` DESC" + (limit != null ? " LIMIT ? OFFSET ?" : "");
-        else query = "SELECT * FROM `bank_accounts` WHERE `balance` IS NOT NULL AND `type` = ? ORDER BY `balance` DESC" + (limit != null ? " LIMIT ? OFFSET ?" : "");
+        if (type == null) query = "SELECT * FROM `bank_accounts` WHERE `balance` IS NOT NULL AND `balance` > 0 ORDER BY `balance` DESC" + (limit != null ? " LIMIT ? OFFSET ?" : "");
+        else query = "SELECT * FROM `bank_accounts` WHERE `balance` IS NOT NULL AND `balance` > 0 AND `type` = ? ORDER BY `balance` DESC" + (limit != null ? " LIMIT ? OFFSET ?" : "");
         try (final @NotNull Connection conn = BankAccounts.getInstance().getDb().getConnection();
              final @NotNull PreparedStatement stmt = conn.prepareStatement(query)) {
             if (type != null) {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import pro.cloudnode.smp.bankaccounts.commands.BaltopCommand;
 import pro.cloudnode.smp.bankaccounts.commands.BankCommand;
 import pro.cloudnode.smp.bankaccounts.commands.POSCommand;
 import pro.cloudnode.smp.bankaccounts.events.BlockBreak;
@@ -67,6 +68,7 @@ public final class BankAccounts extends JavaPlugin {
         final @NotNull HashMap<@NotNull String, @NotNull CommandExecutor> commands = new HashMap<>() {{
             put("bank", new BankCommand());
             put("pos", new POSCommand());
+            put("baltop", new BaltopCommand());
         }};
         for (Map.Entry<@NotNull String, @NotNull CommandExecutor> entry : commands.entrySet()) {
             final PluginCommand command = getCommand(entry.getKey());

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -141,6 +141,11 @@ public final class BankConfig {
         return config.getInt("account-limits." + Account.Type.getType(type));
     }
 
+    // baltop.per-page
+    public int baltopPerPage() {
+        return config.getInt("baltop.per-page");
+    }
+
     // transfer-confirmation.enabled
     public boolean transferConfirmationEnabled() {
         return config.getBoolean("transfer-confirmation.enabled");

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -596,6 +596,11 @@ public final class BankConfig {
         return Objects.requireNonNull(config.getString("messages.baltop.entry"));
     }
 
+    // messages.baltop.entry.player
+    public @NotNull String messagesBaltopEntryPlayer() {
+        return Objects.requireNonNull(config.getString("messages.baltop.entry-player"));
+    }
+
     // messages.update-available
     public @NotNull String messagesUpdateAvailable() {
         return Objects.requireNonNull(config.getString("messages.update-available"));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -586,6 +586,16 @@ public final class BankConfig {
         return Objects.requireNonNull(config.getString("messages.whois"));
     }
 
+    // messages.baltop.header
+    public @NotNull String messagesBaltopHeader() {
+        return Objects.requireNonNull(config.getString("messages.baltop.header"));
+    }
+
+    // messages.baltop.entry
+    public @NotNull String messagesBaltopEntry() {
+        return Objects.requireNonNull(config.getString("messages.baltop.entry"));
+    }
+
     // messages.update-available
     public @NotNull String messagesUpdateAvailable() {
         return Objects.requireNonNull(config.getString("messages.update-available"));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Permissions.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Permissions.java
@@ -14,6 +14,7 @@ public final class Permissions {
     public static @NotNull String SET_NAME = "bank.set.name";
     public static @NotNull String FREEZE = "bank.freeze";
     public static @NotNull String DELETE = "bank.delete";
+    public static @NotNull String BALTOP = "bank.baltop";
     public static @NotNull String POS_CREATE = "bank.pos.create";
     public static @NotNull String POS_USE = "bank.pos.use";
     public static @NotNull String RELOAD = "bank.reload";

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
@@ -107,7 +107,7 @@ public final class BaltopCommand extends pro.cloudnode.smp.bankaccounts.Command 
         public static @NotNull BaltopPlayer @NotNull [] get(final int perPage, final int page) {
             final @NotNull List<@NotNull BaltopPlayer> entries = new ArrayList<>();
             try (final @NotNull Connection conn = BankAccounts.getInstance().getDb().getConnection();
-                 final @NotNull PreparedStatement stmt = conn.prepareStatement("SELECT `owner`, SUM(`balance`) AS `balance` FROM `bank_accounts` WHERE `balance` IS NOT NULL GROUP BY `owner` LIMIT ? OFFSET ?;")) {
+                 final @NotNull PreparedStatement stmt = conn.prepareStatement("SELECT `owner`, SUM(`balance`) AS `balance` FROM `bank_accounts` WHERE `balance` IS NOT NULL AND `balance` > 0 GROUP BY `owner` LIMIT ? OFFSET ?;")) {
                 stmt.setInt(1, perPage);
                 stmt.setInt(2, (page - 1) * perPage);
                 final @NotNull ResultSet rs = stmt.executeQuery();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
@@ -31,8 +31,8 @@ public final class BaltopCommand extends pro.cloudnode.smp.bankaccounts.Command 
     public @NotNull List<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
         final @NotNull ArrayList<@NotNull String> suggestions = new ArrayList<>();
         if (!sender.hasPermission(Permissions.BALTOP)) return suggestions;
-        if (args.length == 2) suggestions.addAll(Arrays.asList("personal", "business", "player"));
-        else if (args.length == 3) suggestions.add("1");
+        if (args.length == 1) suggestions.addAll(Arrays.asList("personal", "business", "player"));
+        else if (args.length == 2) suggestions.add("1");
         return suggestions;
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
@@ -45,7 +45,7 @@ public final class BaltopCommand extends pro.cloudnode.smp.bankaccounts.Command 
         final @NotNull String labelArgsString = labelArgs.length > 0 ? " " + String.join(" ", labelArgs) : "";
         final @NotNull String argsString = (args.length > 0 ? " " + String.join(" ", args) : "");
         final @NotNull String cmdPrev = "/baltop" + (type.map(s -> " " + s).orElse("")) + " " + Math.max(1, page - 1);
-        final @NotNull String cmdNext = "/baltop" + (type.map(s -> " " + s).orElse("")) + " " + Math.min(1e9, page + 1);
+        final @NotNull String cmdNext = "/baltop" + (type.map(s -> " " + s).orElse("")) + " " + Math.min(1000000000, page + 1);
 
         final @Nullable Account.Type accountType = type.flatMap(Account.Type::fromString).orElse(null);
         if (accountType != null || type.isEmpty()) {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
@@ -1,0 +1,77 @@
+package pro.cloudnode.smp.bankaccounts.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import pro.cloudnode.smp.bankaccounts.Account;
+import pro.cloudnode.smp.bankaccounts.BankAccounts;
+import pro.cloudnode.smp.bankaccounts.Permissions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public final class BaltopCommand extends pro.cloudnode.smp.bankaccounts.Command {
+    @Override
+    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
+        return run(sender, label, args, new String[0]);
+    }
+
+    @Override
+    public @NotNull List<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
+        final @NotNull ArrayList<@NotNull String> suggestions = new ArrayList<>();
+        if (!sender.hasPermission(Permissions.BALTOP)) return suggestions;
+        if (args.length == 2) suggestions.addAll(Arrays.asList("personal", "business", "player"));
+        else if (args.length == 3) suggestions.add("1");
+        return suggestions;
+    }
+
+    public static boolean run(final @NotNull CommandSender sender, final @NotNull String label, final @NotNull String @NotNull [] args, final @NotNull String @NotNull [] labelArgs) {
+        final @NotNull Optional<@NotNull String> type = args.length > 0 && (args[0].equalsIgnoreCase("personal") || args[0].equalsIgnoreCase("business") || args[0].equalsIgnoreCase("player")) ? Optional.of(args[0]) : Optional.empty();
+        int page = (int) Math.min(1e9, (args.length == 1 && type.isEmpty() && isInteger(args[0])) ? Integer.parseInt(args[0]) : ((args.length > 1 && isInteger(args[1])) ? Integer.parseInt(args[1]) : 1));
+        if (page < 1) page = 1;
+        final int perPage = BankAccounts.getInstance().config().baltopPerPage();
+
+        final @NotNull String labelArgsString = labelArgs.length > 0 ? " " + String.join(" ", labelArgs) : "";
+        final @NotNull String argsString = (args.length > 0 ? " " + String.join(" ", args) : "");
+        final @NotNull String cmdPrev = "/baltop" + (type.map(s -> " " + s).orElse("")) + " " + Math.max(1, page - 1);
+        final @NotNull String cmdNext = "/baltop" + (type.map(s -> " " + s).orElse("")) + " " + Math.min(1e9, page + 1);
+
+        final @Nullable Account.Type accountType = type.flatMap(Account.Type::fromString).orElse(null);
+        if (accountType != null || type.isEmpty()) {
+            final @NotNull String category = accountType != null ? BankAccounts.getInstance().config().messagesTypes(accountType) : "All";
+            final @NotNull Account @NotNull [] accounts = Account.getTopBalance(perPage, page, accountType);
+            sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopHeader()
+                    .replace("<category>", category)
+                    .replace("<page>", String.valueOf(page))
+                    .replace("<cmd-prev>", cmdPrev)
+                    .replace("<cmd-next>", cmdNext));
+            for (int i = 0; i < accounts.length; i++) {
+                final @NotNull Account account = accounts[i];
+                sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBaltopEntry()
+                        .replace("<position>", String.valueOf((page - 1) * perPage + i + 1)), account));
+            }
+        }
+        else {
+            sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopHeader()
+                    .replace("<category>", "Players")
+                    .replace("<page>", String.valueOf(page))
+                    .replace("<cmd-prev>", cmdPrev)
+                    .replace("<cmd-next>", cmdNext));
+            sendMessage(sender, "not implemented");
+        }
+        return true;
+    }
+
+    public static boolean isInteger(final @NotNull String string) {
+        try {
+            Integer.parseInt(string);
+            return true;
+        }
+        catch (final NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -145,6 +145,11 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
                     if (args.length == 2)
                         suggestions.addAll(Arrays.stream(Account.get()).map(account -> account.id).toList());
                 }
+                case "baltop" -> {
+                    if (!sender.hasPermission(Permissions.BALTOP)) return suggestions;
+                    if (args.length == 2) suggestions.addAll(Arrays.asList("personal", "business", "player"));
+                    else if (args.length == 3) suggestions.add("1");
+                }
             }
         }
         return suggestions;
@@ -171,6 +176,7 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             case "transactions", "history" -> transactions(sender, argsSubset, label);
             case "instrument", "card" -> instrument(sender, argsSubset, label);
             case "whois", "who", "info" -> whois(sender, argsSubset, label);
+            case "baltop" -> baltop(sender, argsSubset, label);
             default -> sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsUnknownCommand());
         };
     }
@@ -214,6 +220,8 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
             sendMessage(sender, "<click:suggest_command:/bank instrument ><green>/bank instrument <gray><account>" + (sender.hasPermission(Permissions.INSTRUMENT_CREATE_OTHER) ? " [player]" : "") + "</gray></green> <white>- Create a new instrument</click>");
         if (sender.hasPermission(Permissions.WHOIS))
             sendMessage(sender, "<click:suggest_command:/bank whois ><green>/bank whois <gray><account></gray></green> <white>- Get information about an account</click>");
+        if (sender.hasPermission(Permissions.BALTOP))
+            sendMessage(sender, "<click:suggest_command:/baltop ><green>/baltop <gray>[personal|business|player] [page=1]</gray></green> <white>- Top balance leaderboard</click>");
         if (sender.hasPermission(Permissions.POS_CREATE))
             sendMessage(sender, "<click:suggest_command:/pos ><green>/pos <gray><account> <price> [description]</gray></green> <white>- Create a new point of sale</click>");
         if (sender.hasPermission(Permissions.SET_BALANCE))
@@ -622,6 +630,10 @@ public class BankCommand extends pro.cloudnode.smp.bankaccounts.Command {
         return account
                 .map(value -> sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesWhois(), value)))
                 .orElseGet(() -> sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound()));
+    }
+
+    public static boolean baltop(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
+        return BaltopCommand.run(sender, label, args, new String[]{"baltop"});
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -451,6 +451,15 @@ messages:
         # All placeholders from balance
         # <position> - leaderboard rank number
         entry: "<hover:show_text:'<white><account></white><newline><gray><account-type><dark_gray>:</dark_gray> <green><balance-formatted></green></gray><newline><gray>Owned by <account-owner></gray><newline><gray><account-id></gray>'><gray>#<position></gray> <white><balance-short></white> <green><account></green></hover>"
+        # Baltop player entry
+        # Placeholders:
+        # <position> - leaderboard rank number
+        # <uuid> - Player UUID
+        # <username> - Player username
+        # <balance> - Total balance without formatting, example: 123456.78
+        # <balance-formatted> - Total balance with formatting, example: $123,456.78
+        # <balance-short> - Total balance with formatting, example: $123k
+        entry-player: "<click:suggest_command:/msg <username> ><hover:show_text:'<white><username></white><newline><gray><balance-formatted></gray><newline>'><gray>#<position></gray> <white><balance-short></white> <green><username></green></hover></click>"
 
 
     # New version available

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -85,6 +85,12 @@ account-limits:
     # Business accounts
     1: -1
 
+# Top balance leaderboard
+# Accounts with infinite balance are excluded
+baltop:
+    # How many accounts to show per page
+    per-page: 10
+
 # Transfer confirmation
 transfer-confirmation:
     # If enabled, players will be shown a transfer overview asking them to confirm the transfer

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -438,6 +438,20 @@ messages:
         <gray>Type:</gray> <white><account-type></white>
         <gray>ID: <click:copy_to_clipboard:<account-id>><hover:show_text:'<white>Copy to clipboard</white>'><white><account-id></white></hover></click></gray>
 
+    # Top balances
+    baltop:
+        # Baltop header
+        # Placeholders:
+        # <category> - Baltop category
+        # <page> - Current page number
+        # <cmd-prev> - Command to go to previous page
+        # <cmd-next> - Command to go to next page
+        header: "<green><bold>Baltop</bold></green> <gray>(<category>)</gray><newline><click:run_command:<cmd-prev>><hover:show_text:'<white>Click</white>'><green>← Previous</green></hover></click>     <gray>Page <page></gray>        <click:run_command:<cmd-next>><hover:show_text:'<white>Click</white>'><green>Next →</green></hover></click><newline><dark_gray><st>                                            </st></dark_gray>"
+        # Baltop entry
+        # All placeholders from balance
+        # <position> - leaderboard rank number
+        entry: "<hover:show_text:'<white><account></white><newline><gray><account-type><dark_gray>:</dark_gray> <green><balance-formatted></green></gray><newline><gray>Owned by <account-owner></gray><newline><gray><account-id></gray>'><gray>#<position></gray> <white><balance-short></white> <green><account></green></hover>"
+
 
     # New version available
     # Placeholders:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,3 +12,6 @@ commands:
     pos:
         description: Create point of sale
         usage: /<command>
+    baltop:
+        description: Balance leaderboard
+        usage: /<command>


### PR DESCRIPTION
List accounts or players ranked by their balance

### Commands
All commands also work with `/bank baltop`

`/baltop [type|page] [page]`
Type is one of:
- `business` baltop with business accounts only
- `personal` baltop with personal accounts only
- `player` baltop of players. the sum of all their accounts is used
- no type specified - baltop for both business and personal accounts

`page` is an optional number 1–1000000000. Default 1

**Examples**
`/baltop`
`/baltop 2`
`/baltop personal 2`
`/baltop business`

### Permissions
`bank.baltop`

![image](https://github.com/cloudnode-pro/BankAccounts/assets/66572326/297dc584-a94c-4c08-8dd6-0ad15ceb149f)
