### PR TITLE
Config refactor

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -110,6 +110,14 @@ public class Account {
         );
     }
 
+    public final @NotNull String name() {
+        return this.name == null ? (this.type == Type.PERSONAL && this.owner.getName() != null ? this.owner.getName() : this.id) : this.name;
+    }
+
+    public final @NotNull Component ownerName() {
+        return this.owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) ? MiniMessage.miniMessage().deserialize("<i>the server</i>") : this.owner.getName() == null ? MiniMessage.miniMessage().deserialize("<i>unknown player</i>") : Component.text(this.owner.getName());
+    }
+
     /**
      * Update account balance
      * @param diff Balance difference (positive or negative)
@@ -157,12 +165,11 @@ public class Account {
         final @NotNull Material material = BankAccounts.getInstance().config().instrumentsMaterial();
         final @NotNull ItemStack instrument = new ItemStack(material);
 
-        final @NotNull String name = BankAccounts.getInstance().config().instrumentsName();
         final @NotNull List<@NotNull String> lore = BankAccounts.getInstance().config().instrumentsLore();
         final boolean glint = BankAccounts.getInstance().config().instrumentsGlintEnabled();
 
         final @NotNull ItemMeta meta = instrument.getItemMeta();
-        meta.displayName(this.instrumentPlaceholders(name));
+        meta.displayName(BankAccounts.getInstance().config().instrumentsName(this, LocalDateTime.now(ZoneOffset.UTC)));
         meta.lore(lore.stream().map(this::instrumentPlaceholders).toList());
 
         if (glint) {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -118,6 +118,10 @@ public class Account {
         return this.owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) ? MiniMessage.miniMessage().deserialize("<i>the server</i>") : this.owner.getName() == null ? MiniMessage.miniMessage().deserialize("<i>unknown player</i>") : Component.text(this.owner.getName());
     }
 
+    public final @NotNull String ownerNameUnparsed() {
+        return this.owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) ? "<i>the server</i>" : this.owner.getName() == null ? "<i>unknown player</i>" : this.owner.getName();
+    }
+
     /**
      * Update account balance
      * @param diff Balance difference (positive or negative)

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -165,14 +165,11 @@ public class Account {
         final @NotNull Material material = BankAccounts.getInstance().config().instrumentsMaterial();
         final @NotNull ItemStack instrument = new ItemStack(material);
 
-        final @NotNull List<@NotNull String> lore = BankAccounts.getInstance().config().instrumentsLore();
-        final boolean glint = BankAccounts.getInstance().config().instrumentsGlintEnabled();
-
         final @NotNull ItemMeta meta = instrument.getItemMeta();
         meta.displayName(BankAccounts.getInstance().config().instrumentsName(this, LocalDateTime.now(ZoneOffset.UTC)));
-        meta.lore(lore.stream().map(this::instrumentPlaceholders).toList());
+        meta.lore(BankAccounts.getInstance().config().instrumentsLore(this, LocalDateTime.now(ZoneOffset.UTC)));
 
-        if (glint) {
+        if (BankAccounts.getInstance().config().instrumentsGlintEnabled()) {
             final @NotNull Enchantment enchantment = BankAccounts.getInstance().config().instrumentsGlintEnchantment();
             meta.addEnchant(enchantment, 1, true);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -1,10 +1,7 @@
 package pro.cloudnode.smp.bankaccounts;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
@@ -24,9 +21,7 @@ import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -194,20 +189,6 @@ public class Account {
      */
     public static boolean isInstrument(final @NotNull ItemStack item) {
         return item.getItemMeta().getPersistentDataContainer().has(BankAccounts.Key.INSTRUMENT_ACCOUNT, PersistentDataType.STRING);
-    }
-
-    /**
-     * Set placeholders for instrument
-     * @param string String to set placeholders in
-     */
-    public final @NotNull Component instrumentPlaceholders (final @NotNull String string) {
-        return MiniMessage.miniMessage().deserialize(string,
-                Placeholder.unparsed("account", this.name == null ? (this.type == Type.PERSONAL && this.owner.getName() != null ? this.owner.getName() : this.id) : this.name),
-                Placeholder.parsed("account-id", this.id),
-                Placeholder.parsed("account-type", this.type.getName()),
-                Placeholder.parsed("account-owner", this.owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) ? "<i>the server</i>" : this.owner.getName() == null ? "<i>unknown player</i>" : this.owner.getName()),
-                Formatter.date("date", LocalDateTime.now(ZoneOffset.UTC))
-        ).decoration(TextDecoration.ITALIC, false);
     }
 
     /**
@@ -383,58 +364,6 @@ public class Account {
         } catch (final @NotNull Exception e) {
             BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not delete account: " + id, e);
         }
-    }
-
-    /**
-     * Account placeholders
-     * @param string String to deserialize with MiniMessage and apply placeholders to
-     * @param accounts Accounts to apply placeholders to
-     */
-    public static String placeholdersString(@NotNull String string, HashMap<String, @NotNull Account> accounts) {
-        for (Map.Entry<String, Account> entry : accounts.entrySet()) {
-            String name = entry.getKey();
-            Account account = entry.getValue();
-            String prefix = name.isEmpty() ? "" : name + "-";
-            string = string.replace("<" + prefix + "account>", account.name == null ? (account.type == Account.Type.PERSONAL && account.owner.getName() != null ? account.owner.getName() : account.id) : account.name)
-                    .replace("<" + prefix + "account-id>", account.id)
-                    .replace("<" + prefix + "account-type>", account.type.getName())
-                    .replace("<" + prefix + "account-owner>", account.owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) ? "<i>the server</i>" : account.owner.getName() == null ? "<i>unknown player</i>" : account.owner.getName())
-                    .replace("<" + prefix + "balance>", account.balance == null ? "∞" : account.balance.toPlainString())
-                    .replace("<" + prefix + "balance-formatted>", BankAccounts.formatCurrency(account.balance))
-                    .replace("<" + prefix + "balance-short>", BankAccounts.formatCurrencyShort(account.balance));
-        }
-        return string;
-    }
-
-    /**
-     * Account placeholders
-     * @param string String to deserialize with MiniMessage and apply placeholders to
-     * @param accounts Accounts to apply placeholders to
-     */
-    public static Component placeholders(@NotNull String string, HashMap<String, Account> accounts) {
-        return MiniMessage.miniMessage().deserialize(placeholdersString(string, accounts));
-    }
-
-    /**
-     * Account placeholders
-     * @param string String to deserialize with MiniMessage and apply placeholders to
-     * @param account Account to apply placeholders to
-     */
-    public static Component placeholders(@NotNull String string, Account account) {
-        return placeholders(string, new HashMap<>() {{
-            put("", account);
-        }});
-    }
-
-    /**
-     * Account placeholders
-     * @param string String to deserialize with MiniMessage and apply placeholders to
-     * @param account Account to apply placeholders to
-     */
-    public static String placeholdersString(@NotNull String string, Account account) {
-        return placeholdersString(string, new HashMap<>() {{
-            put("", account);
-        }});
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -237,7 +237,7 @@ public class Account {
             return accounts.toArray(new Account[0]);
         }
         catch (final @NotNull Exception e) {
-            BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not get accounts for: " + owner.getUniqueId().toString() + " (" + owner.getName() + "), type = " + (type == null ? "all" : type.name()), e);
+            BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not get accounts for: " + owner.getUniqueId() + " (" + owner.getName() + "), type = " + (type == null ? "all" : type.name()), e);
             return new Account[0];
         }
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -11,9 +11,6 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
@@ -148,13 +145,11 @@ public final class BankAccounts extends JavaPlugin {
         getInstance().setupDbSource();
         getInstance().initDbWrapper();
         createServerAccount();
-        getInstance().getServer().getScheduler().runTaskAsynchronously(getInstance(), () -> {
-            checkForUpdates().ifPresent(latestVersion -> {
-                getInstance().getLogger().warning("An update is available: " + latestVersion);
-                getInstance().getLogger().warning("Please update to the latest version to benefit from bug fixes, security patches, new features and support.");
-                getInstance().getLogger().warning("Update details: https://modrinth.com/plugin/bankaccounts/version/" + latestVersion);
-            });
-        });
+        getInstance().getServer().getScheduler().runTaskAsynchronously(getInstance(), () -> checkForUpdates().ifPresent(latestVersion -> {
+            getInstance().getLogger().warning("An update is available: " + latestVersion);
+            getInstance().getLogger().warning("Please update to the latest version to benefit from bug fixes, security patches, new features and support.");
+            getInstance().getLogger().warning("Update details: https://modrinth.com/plugin/bankaccounts/version/" + latestVersion);
+        }));
         getInstance().startInterestTimer();
     }
 
@@ -385,32 +380,6 @@ public final class BankAccounts extends JavaPlugin {
             plugin.getLogger().log(Level.WARNING, "Failed to check for updates", e);
         }
         return Optional.empty();
-    }
-
-    /**
-     * Check if an inventory can fit items
-     *
-     * @param inventory The inventory that you want to hold the items
-     * @param items The items to check if they can fit in the inventory
-     * @return A HashMap containing items that didn't fit.
-     */
-    public static @NotNull HashMap<@NotNull Integer, @NotNull ItemStack> canFit(final @NotNull Inventory inventory, final @NotNull ItemStack... items) {
-        final @NotNull Inventory inv = getInstance().getServer().createInventory(null, inventory.getSize());
-        inv.setContents(inventory.getContents());
-        final @NotNull HashMap<@NotNull Integer, @NotNull ItemStack> didNotFit = inv.addItem(items);
-        inv.close();
-        return didNotFit;
-    }
-
-    /**
-     * Check if entity's inventory can fit items
-     *
-     * @param entity The entity that you want to hold the items
-     * @param items The items to check if they can fit in the inventory
-     * @return A HashMap containing items that didn't fit.
-     */
-    public static @NotNull HashMap<@NotNull Integer, @NotNull ItemStack> canFit(final @NotNull InventoryHolder entity, final @NotNull ItemStack... items) {
-        return canFit(entity.getInventory(), items);
     }
 
     public static final class Key {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -283,8 +283,7 @@ public final class BankAccounts extends JavaPlugin {
      */
     public static String formatCurrency(final @Nullable BigDecimal amount) {
         if (amount == null) return getCurrencySymbol() + "∞";
-        final @Nullable String format = getInstance().config().currencyFormat();
-        return (amount.compareTo(BigDecimal.ZERO) < 0 ? "<red>-" : "") + getCurrencySymbol() + new DecimalFormat(format).format(amount.abs().setScale(2, RoundingMode.HALF_UP)) + (amount.compareTo(BigDecimal.ZERO) < 0 ? "</red>" : "");
+        return (amount.compareTo(BigDecimal.ZERO) < 0 ? "<red>-" : "") + getCurrencySymbol() + getInstance().config().currencyFormat().format(amount.abs().setScale(2, RoundingMode.HALF_UP)) + (amount.compareTo(BigDecimal.ZERO) < 0 ? "</red>" : "");
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -38,7 +38,6 @@ import java.net.http.HttpResponse;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -245,12 +244,7 @@ public final class BankAccounts extends JavaPlugin {
     private void interestPayment(final @NotNull Account account, final @NotNull BigDecimal amount, final double rate, final @NotNull Account serverAccount) {
         if (account.balance == null) return;
         if (account.id.equals(serverAccount.id)) return;
-        final @NotNull String description = this.config().interestDescription(account.type)
-                .replace("<rate>", String.valueOf(rate))
-                .replace("<rate-formatted>", new DecimalFormat("#.##").format(rate) + "%")
-                .replace("<balance>", account.balance.toPlainString())
-                .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
-                .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance));
+        final @NotNull String description = this.config().interestDescription(account.type, rate, account);
 
         try {
             // interest paid to the bank

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -333,8 +333,21 @@ public final class BankConfig {
     }
 
     // pos.confirm.name
-    public @NotNull String posConfirmName() {
-        return Objects.requireNonNull(config.getString("pos.confirm.name"));
+    public @NotNull Component posConfirmName(final @NotNull POS pos, final @NotNull Account buyer) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("pos.confirm.name")),
+                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
+                Placeholder.unparsed("price", pos.price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price)),
+                Placeholder.unparsed("account", buyer.name()),
+                Placeholder.unparsed("account-id", buyer.id),
+                Placeholder.unparsed("account-type", buyer.type.getName()),
+                Placeholder.component("account-owner", buyer.ownerName()),
+                Placeholder.unparsed("balance", buyer.balance == null ? "∞" : buyer.balance.toPlainString()),
+                Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(buyer.balance)),
+                Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(buyer.balance))
+        );
     }
 
     // pos.confirm.lore

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -11,7 +11,6 @@ import org.bukkit.Registry;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.HumanEntity;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;
@@ -652,8 +651,17 @@ public final class BankConfig {
     }
 
     // messages.balance
-    public @NotNull String messagesBalance() {
-        return Objects.requireNonNull(config.getString("messages.balance"));
+    public @NotNull Component messagesBalance(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.balance"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.list-accounts.header

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -274,8 +274,14 @@ public final class BankConfig {
     }
 
     // pos.info.lore-owner
-    public @NotNull List<@NotNull String> posInfoLoreOwner() {
-        return Objects.requireNonNull(config.getStringList("pos.info.lore-owner"));
+    public @NotNull List<@NotNull Component> posInfoLoreOwner(final @NotNull POS pos) {
+        return Objects.requireNonNull(config.getStringList("pos.info.lore-owner")).stream().map(string -> MiniMessage.miniMessage().deserialize(
+                string,
+                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
+                Placeholder.unparsed("price", pos.price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
+        ).decoration(TextDecoration.ITALIC, false)).toList();
     }
 
     // pos.info.lore-buyer

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -351,8 +351,21 @@ public final class BankConfig {
     }
 
     // pos.confirm.lore
-    public @NotNull List<@NotNull String> posConfirmLore() {
-        return Objects.requireNonNull(config.getStringList("pos.confirm.lore"));
+    public @NotNull List<@NotNull Component> posConfirmLore(final @NotNull POS pos, final @NotNull Account buyer) {
+        return Objects.requireNonNull(config.getStringList("pos.confirm.lore")).stream().map(string -> MiniMessage.miniMessage().deserialize(
+            string,
+            Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
+            Placeholder.unparsed("price", pos.price.toPlainString()),
+            Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
+            Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price)),
+            Placeholder.unparsed("account", buyer.name()),
+            Placeholder.unparsed("account-id", buyer.id),
+            Placeholder.unparsed("account-type", buyer.type.getName()),
+            Placeholder.component("account-owner", buyer.ownerName()),
+            Placeholder.unparsed("balance", buyer.balance == null ? "∞" : buyer.balance.toPlainString()),
+            Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(buyer.balance)),
+            Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(buyer.balance))
+        )).toList();
     }
 
     // pos.decline.material

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -853,8 +853,21 @@ public final class BankConfig {
     }
 
     // messages.history.header
-    public @NotNull String messagesHistoryHeader() {
-        return Objects.requireNonNull(config.getString("messages.history.header"));
+    public @NotNull Component messagesHistoryHeader(final @NotNull Account account, final int page, final int maxPage) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.history.header"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+                        .replace("<page>", String.valueOf(page))
+                        .replace("<max-page>", String.valueOf(maxPage))
+                        .replace("<cmd-prev>", "/bank transactions " + account.id + " " + (page - 1))
+                        .replace("<cmd-next>", "/bank transactions " + account.id + " " + (page + 1))
+        );
     }
 
     // messages.history.entry
@@ -863,8 +876,21 @@ public final class BankConfig {
     }
 
     // messages.history.footer
-    public @NotNull String messagesHistoryFooter() {
-        return Objects.requireNonNull(config.getString("messages.history.footer"));
+    public @NotNull Component messagesHistoryFooter(final @NotNull Account account, final int page, final int maxPage) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.history.footer"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+                        .replace("<page>", String.valueOf(page))
+                        .replace("<max-page>", String.valueOf(maxPage))
+                        .replace("<cmd-prev>", "/bank transactions " + account.id + " " + (page - 1))
+                        .replace("<cmd-next>", "/bank transactions " + account.id + " " + (page + 1))
+        );
     }
 
     // messages.history.no-transactions

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -10,6 +10,8 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;
@@ -411,9 +413,9 @@ public final class BankConfig {
     // messages.command-usage
     public @NotNull Component messagesCommandUsage(final @NotNull String command, final @NotNull String arguments) {
         return MiniMessage.miniMessage().deserialize(
-                Objects.requireNonNull(config.getString("messages.command-usage")),
-                Placeholder.unparsed("command", command),
-                Placeholder.unparsed("arguments", arguments)
+                Objects.requireNonNull(config.getString("messages.command-usage"))
+                        .replace("<command>", command)
+                        .replace("<arguments>", arguments)
         );
     }
 
@@ -423,168 +425,230 @@ public final class BankConfig {
     }
 
     // messages.errors.no-accounts
-    public @NotNull String messagesErrorsNoAccounts() {
-        return Objects.requireNonNull(config.getString("messages.errors.no-accounts"));
+    public @NotNull Component messagesErrorsNoAccounts() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.no-accounts")));
     }
 
     // messages.errors.no-permission
-    public @NotNull String messagesErrorsNoPermission() {
-        return Objects.requireNonNull(config.getString("messages.errors.no-permission"));
+    public @NotNull Component messagesErrorsNoPermission() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.no-permission")));
     }
 
     // messages.errors.account-not-found
-    public @NotNull String messagesErrorsAccountNotFound() {
-        return Objects.requireNonNull(config.getString("messages.errors.account-not-found"));
+    public @NotNull Component messagesErrorsAccountNotFound() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.account-not-found")));
     }
 
     // messages.errors.unknown-command
-    public @NotNull String messagesErrorsUnknownCommand() {
-        return Objects.requireNonNull(config.getString("messages.errors.unknown-command"));
+    public @NotNull Component messagesErrorsUnknownCommand() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.unknown-command")));
     }
 
     // messages.errors.max-accounts
-    public @NotNull String messagesErrorsMaxAccounts() {
-        return Objects.requireNonNull(config.getString("messages.errors.max-accounts"));
+    public @NotNull Component messagesErrorsMaxAccounts(final @NotNull Account.Type type, final int limit) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.max-accounts"))
+                        .replace("<type>", type.getName())
+                        .replace("<limit>", String.valueOf(limit))
+        );
     }
 
     // messages.errors.rename-personal
-    public @NotNull String messagesErrorsRenamePersonal() {
-        return Objects.requireNonNull(config.getString("messages.errors.rename-personal"));
+    public @NotNull Component messagesErrorsRenamePersonal() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.rename-personal")));
     }
 
     // messages.errors.not-account-owner
-    public @NotNull String messagesErrorsNotAccountOwner() {
-        return Objects.requireNonNull(config.getString("messages.errors.not-account-owner"));
+    public @NotNull Component messagesErrorsNotAccountOwner() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.not-account-owner")));
     }
 
     // messages.errors.frozen
-    public @NotNull String messagesErrorsFrozen() {
-        return Objects.requireNonNull(config.getString("messages.errors.frozen"));
+    public @NotNull Component messagesErrorsFrozen(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.frozen"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.errors.same-from-to
-    public @NotNull String messagesErrorsSameFromTo() {
-        return Objects.requireNonNull(config.getString("messages.errors.same-from-to"));
+    public @NotNull Component messagesErrorsSameFromTo() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.same-from-to")));
     }
 
     // messages.errors.transfer-self-only
-    public @NotNull String messagesErrorsTransferSelfOnly() {
-        return Objects.requireNonNull(config.getString("messages.errors.transfer-self-only"));
+    public @NotNull Component messagesErrorsTransferSelfOnly() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.transfer-self-only")));
     }
 
     // messages.errors.transfer-other-only
-    public @NotNull String messagesErrorsTransferOtherOnly() {
-        return Objects.requireNonNull(config.getString("messages.errors.transfer-other-only"));
+    public @NotNull Component messagesErrorsTransferOtherOnly() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.transfer-other-only")));
     }
 
     // messages.errors.invalid-number
-    public @NotNull String messagesErrorsInvalidNumber() {
-        return Objects.requireNonNull(config.getString("messages.errors.invalid-number"));
+    public @NotNull Component messagesErrorsInvalidNumber(final @NotNull String number) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.invalid-number"))
+                        .replace("<number>", number)
+        );
     }
 
     // messages.errors.negative-transfer
-    public @NotNull String messagesErrorsNegativeTransfer() {
-        return Objects.requireNonNull(config.getString("messages.errors.negative-transfer"));
+    public @NotNull Component messagesErrorsNegativeTransfer() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.negative-transfer")));
     }
 
     // messages.errors.insufficient-funds
-    public @NotNull String messagesErrorsInsufficientFunds() {
-        return Objects.requireNonNull(config.getString("messages.errors.insufficient-funds"));
+    public @NotNull Component messagesErrorsInsufficientFunds(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.insufficient-funds"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.errors.closing-balance
-    public @NotNull String messagesErrorsClosingBalance() {
-        return Objects.requireNonNull(config.getString("messages.errors.closing-balance"));
+    public @NotNull Component messagesErrorsClosingBalance(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.closing-balance"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.errors.closing-personal
-    public @NotNull String messagesErrorsClosingPersonal() {
-        return Objects.requireNonNull(config.getString("messages.errors.closing-personal"));
+    public @NotNull Component messagesErrorsClosingPersonal() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.closing-personal")));
     }
 
     // messages.errors.player-only
-    public @NotNull String messagesErrorsPlayerOnly() {
-        return Objects.requireNonNull(config.getString("messages.errors.player-only"));
+    public @NotNull Component messagesErrorsPlayerOnly() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.player-only")));
     }
 
     // messages.errors.player-not-found
-    public @NotNull String messagesErrorsPlayerNotFound() {
-        return Objects.requireNonNull(config.getString("messages.errors.player-not-found"));
+    public @NotNull Component messagesErrorsPlayerNotFound() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.player-not-found")));
     }
 
     // messages.errors.instrument-requires-item
-    public @NotNull String messagesErrorsInstrumentRequiresItem() {
-        return Objects.requireNonNull(config.getString("messages.errors.instrument-requires-item"));
+    public @NotNull Component messagesErrorsInstrumentRequiresItem(final @NotNull Material material) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.instrument-requires-item"))
+                        .replace("<material-key>", material.translationKey())
+                        .replace("<material>", material.name())
+        );
     }
 
     // messages.errors.target-inventory-full
-    public @NotNull String messagesErrorsTargetInventoryFull() {
-        return Objects.requireNonNull(config.getString("messages.errors.target-inventory-full"));
+    public @NotNull Component messagesErrorsTargetInventoryFull(final @NotNull HumanEntity player) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.target-inventory-full"))
+                        .replace("<player>", player.getName())
+        );
     }
 
     // messages.errors.block-too-far
-    public @NotNull String messagesErrorsBlockTooFar() {
-        return Objects.requireNonNull(config.getString("messages.errors.block-too-far"));
+    public @NotNull Component messagesErrorsBlockTooFar() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.block-too-far")));
     }
 
     // messages.errors.pos-already-exists
-    public @NotNull String messagesErrorsPosAlreadyExists() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-already-exists"));
+    public @NotNull Component messagesErrorsPosAlreadyExists() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-already-exists")));
     }
 
     // messages.errors.pos-not-chest
-    public @NotNull String messagesErrorsPosNotChest() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-not-chest"));
+    public @NotNull Component messagesErrorsPosNotChest() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-not-chest")));
     }
 
     // messages.errors.pos-double-chest
-    public @NotNull String messagesErrorsPosDoubleChest() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-double-chest"));
+    public @NotNull Component messagesErrorsPosDoubleChest() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-double-chest")));
     }
 
     // messages.errors.pos-empty
-    public @NotNull String messagesErrorsPosEmpty() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-empty"));
+    public @NotNull Component messagesErrorsPosEmpty() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-empty")));
     }
 
     // messages.errors.pos-invalid-card
-    public @NotNull String messagesErrorsPosInvalidCard() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-invalid-card"));
+    public @NotNull Component messagesErrorsPosInvalidCard() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-invalid-card")));
     }
 
     // messages.errors.pos-no-permission
-    public @NotNull String messagesErrorsPosNoPermission() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-no-permission"));
+    public @NotNull Component messagesErrorsPosNoPermission() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-no-permission")));
     }
 
     // messages.errors.no-card
-    public @NotNull String messagesErrorsNoCard() {
-        return Objects.requireNonNull(config.getString("messages.errors.no-card"));
+    public @NotNull Component messagesErrorsNoCard() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.no-card")));
     }
 
     // messages.errors.pos-items-changed
-    public @NotNull String messagesErrorsPosItemsChanged() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-items-changed"));
+    public @NotNull Component messagesErrorsPosItemsChanged() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-items-changed")));
     }
 
     // messages.errors.pos-create-business-only
-    public @NotNull String messagesErrorsPosCreateBusinessOnly() {
-        return Objects.requireNonNull(config.getString("messages.errors.pos-create-business-only"));
+    public @NotNull Component messagesErrorsPosCreateBusinessOnly() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.pos-create-business-only")));
     }
 
     // messages.errors.disallowed-characters
-    public @NotNull String messagesErrorsDisallowedCharacters() {
-        return Objects.requireNonNull(config.getString("messages.errors.disallowed-characters"));
+    public @NotNull Component messagesErrorsDisallowedCharacters(final @NotNull String characters) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.disallowed-characters"))
+                        .replace("<characters>", characters)
+        );
     }
 
     // messages.errors.already-frozen
-    public @NotNull String messagesErrorsAlreadyFrozen() {
-        return Objects.requireNonNull(config.getString("messages.errors.already-frozen"));
+    public @NotNull Component messagesErrorsAlreadyFrozen(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.already-frozen"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.errors.not-frozen
-    public @NotNull String messagesErrorsNotFrozen() {
-        return Objects.requireNonNull(config.getString("messages.errors.not-frozen"));
+    public @NotNull Component messagesErrorsNotFrozen(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.errors.not-frozen"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.balance

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -11,9 +11,7 @@ import org.bukkit.Registry;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
@@ -226,13 +224,13 @@ public final class BankConfig {
     }
 
     // pos.title
-    public @NotNull Component posTitle(final @Nullable String description, final @NotNull BigDecimal price) {
+    public @NotNull Component posTitle(final @NotNull POS pos) {
         return MiniMessage.miniMessage().deserialize(
                 Objects.requireNonNull(config.getString("pos.title")),
-                Placeholder.unparsed("description", description == null ? "no description" : description),
-                Placeholder.unparsed("price", price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(price))
+                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
+                Placeholder.unparsed("price", pos.price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
         );
     }
 
@@ -247,31 +245,31 @@ public final class BankConfig {
     }
 
     // pos.info.name-owner
-    public @NotNull Component posInfoNameOwner(final @Nullable String description, final @NotNull BigDecimal price) {
+    public @NotNull Component posInfoNameOwner(final @NotNull POS pos) {
         return MiniMessage.miniMessage().deserialize(
                 Objects.requireNonNull(config.getString("pos.info.name-owner")),
-                Placeholder.unparsed("description", description == null ? "no description" : description),
-                Placeholder.unparsed("price", price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(price))
+                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
+                Placeholder.unparsed("price", pos.price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
         ).decoration(TextDecoration.ITALIC, false);
     }
 
     // pos.info.name-buyer
-    public @NotNull Component posInfoNameBuyer(final @Nullable String description, final @NotNull BigDecimal price, final @NotNull Account account) {
+    public @NotNull Component posInfoNameBuyer(final @NotNull POS pos) {
         return MiniMessage.miniMessage().deserialize(
                 Objects.requireNonNull(config.getString("pos.info.name-buyer")),
-                Placeholder.unparsed("description", description == null ? "no description" : description),
-                Placeholder.unparsed("price", price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(price)),
-                Placeholder.unparsed("account", account.name()),
-                Placeholder.unparsed("account-id", account.id),
-                Placeholder.unparsed("account-type", account.type.getName()),
-                Placeholder.component("account-owner", account.ownerName()),
-                Placeholder.unparsed("balance", account.balance == null ? "∞" : account.balance.toPlainString()),
-                Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(account.balance)),
-                Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(account.balance))
+                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
+                Placeholder.unparsed("price", pos.price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price)),
+                Placeholder.unparsed("account", pos.seller.name()),
+                Placeholder.unparsed("account-id", pos.seller.id),
+                Placeholder.unparsed("account-type", pos.seller.type.getName()),
+                Placeholder.component("account-owner", pos.seller.ownerName()),
+                Placeholder.unparsed("balance", pos.seller.balance == null ? "∞" : pos.seller.balance.toPlainString()),
+                Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(pos.seller.balance)),
+                Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(pos.seller.balance))
         ).decoration(TextDecoration.ITALIC, false);
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -6,6 +6,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.jetbrains.annotations.NotNull;
 
+import java.text.DecimalFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -98,8 +99,8 @@ public final class BankConfig {
     }
 
     // currency.format
-    public @NotNull String currencyFormat() {
-        return Objects.requireNonNull(config.getString("currency.format"));
+    public @NotNull DecimalFormat currencyFormat() {
+        return new DecimalFormat(Objects.requireNonNull(config.getString("currency.format")));
     }
 
     // starting-balance

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import pro.cloudnode.smp.bankaccounts.commands.BaltopCommand;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
@@ -1040,18 +1041,45 @@ public final class BankConfig {
     }
 
     // messages.baltop.header
-    public @NotNull String messagesBaltopHeader() {
-        return Objects.requireNonNull(config.getString("messages.baltop.header"));
+    public @NotNull Component messagesBaltopHeader(final @NotNull String category, final int page, final @NotNull String cmdPrev, final @NotNull String cmdNext) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.baltop.header"))
+                        .replace("<category>", category)
+                        .replace("<page>", String.valueOf(page))
+                        .replace("<cmd-prev>", cmdPrev)
+                        .replace("<cmd-next>", cmdNext)
+        );
     }
 
     // messages.baltop.entry
-    public @NotNull String messagesBaltopEntry() {
-        return Objects.requireNonNull(config.getString("messages.baltop.entry"));
+    public @NotNull Component messagesBaltopEntry(final @NotNull Account account, final int position) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.baltop.entry"))
+                .replace("<account>", account.name())
+                .replace("<account-id>", account.id)
+                .replace("<account-type>", account.type.getName())
+                .replace("<account-owner>", account.ownerNameUnparsed())
+                .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+                .replace("<position>", String.valueOf(position))
+        );
     }
 
-    // messages.baltop.entry.player
-    public @NotNull String messagesBaltopEntryPlayer() {
-        return Objects.requireNonNull(config.getString("messages.baltop.entry-player"));
+    // messages.baltop.entry-player
+    public @NotNull Component messagesBaltopEntryPlayer(final @NotNull BaltopCommand.BaltopPlayer entry, final int position) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.baltop.entry-player"))
+                        .replace("<position>", String.valueOf(position))
+                        .replace("<uuid>", entry.uuid.toString())
+                        .replace("<username>", entry.uuid.toString().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId().toString())
+                                ? "the Server"
+                                : Optional.ofNullable(BankAccounts.getInstance().getServer().getOfflinePlayer(entry.uuid).getName())
+                                    .orElse("Unknown Player"))
+                        .replace("<balance>", entry.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(entry.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(entry.balance))
+        );
     }
 
     // messages.update-available

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -1026,8 +1026,17 @@ public final class BankConfig {
     }
 
     // messages.whois
-    public @NotNull String messagesWhois() {
-        return Objects.requireNonNull(config.getString("messages.whois"));
+    public @NotNull Component messagesWhois(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.whois"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.baltop.header

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -313,8 +313,8 @@ public final class BankConfig {
     }
 
     // pos.delete.name
-    public @NotNull String posDeleteName() {
-        return Objects.requireNonNull(config.getString("pos.delete.name"));
+    public @NotNull Component posDeleteName() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("pos.delete.name"))).decoration(TextDecoration.ITALIC, false);
     }
 
     // pos.delete.lore

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -384,8 +384,8 @@ public final class BankConfig {
     }
 
     // pos.decline.lore
-    public @NotNull List<@NotNull String> posDeclineLore() {
-        return Objects.requireNonNull(config.getStringList("pos.decline.lore"));
+    public @NotNull List<@NotNull Component> posDeclineLore() {
+        return Objects.requireNonNull(config.getStringList("pos.decline.lore")).stream().map(string -> MiniMessage.miniMessage().deserialize(string).decoration(TextDecoration.ITALIC, false)).toList();
     }
 
     // interest.*.rate

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -193,7 +193,7 @@ public final class BankConfig {
                 Placeholder.unparsed("account-type", account.type.getName()),
                 Placeholder.component("account-owner", account.ownerName()),
                 Formatter.date("date", created)
-        );
+        ).decoration(TextDecoration.ITALIC, false);
     }
 
     // instruments.lore
@@ -205,7 +205,7 @@ public final class BankConfig {
                 Placeholder.unparsed("account-type", account.type.getName()),
                 Placeholder.component("account-owner", account.ownerName()),
                 Formatter.date("date", created)
-        )).toList();
+        ).decoration(TextDecoration.ITALIC, false)).toList();
     }
 
     // instruments.glint.enabled

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -399,8 +399,13 @@ public final class BankConfig {
     }
 
     // interest.*.description
-    public @NotNull String interestDescription(final @NotNull Account.Type type) {
-        return Objects.requireNonNull(config.getString("interest." + Account.Type.getType(type) + ".description"));
+    public @NotNull String interestDescription(final @NotNull Account.Type type, final double rate, final @NotNull Account account) {
+        return Objects.requireNonNull(config.getString("interest." + Account.Type.getType(type) + ".description"))
+                .replace("<rate>", String.valueOf(rate))
+                .replace("<rate-formatted>", new DecimalFormat("#.##").format(rate) + "%")
+                .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance));
     }
 
     // messages.command-usage

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -684,38 +684,92 @@ public final class BankConfig {
     }
 
     // messages.reload
-    public @NotNull String messagesReload() {
-        return Objects.requireNonNull(config.getString("messages.reload"));
+    public @NotNull Component messagesReload() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.reload")));
     }
 
     // messages.account-created
-    public @NotNull String messagesAccountCreated() {
-        return Objects.requireNonNull(config.getString("messages.account-created"));
+    public @NotNull Component messagesAccountCreated(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.account-created"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.balance-set
-    public @NotNull String messagesBalanceSet() {
-        return Objects.requireNonNull(config.getString("messages.balance-set"));
+    public @NotNull Component messagesBalanceSet(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.balance-set"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.name-set
-    public @NotNull String messagesNameSet() {
-        return Objects.requireNonNull(config.getString("messages.name-set"));
+    public @NotNull Component messagesNameSet(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.name-set"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.account-frozen
-    public @NotNull String messagesAccountFrozen() {
-        return Objects.requireNonNull(config.getString("messages.account-frozen"));
+    public @NotNull Component messagesAccountFrozen(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.account-frozen"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.account-unfrozen
-    public @NotNull String messagesAccountUnfrozen() {
-        return Objects.requireNonNull(config.getString("messages.account-unfrozen"));
+    public @NotNull Component messagesAccountUnfrozen(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.account-unfrozen"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.account-deleted
-    public @NotNull String messagesAccountDeleted() {
-        return Objects.requireNonNull(config.getString("messages.account-deleted"));
+    public @NotNull Component messagesAccountDeleted(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.account-deleted"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.confirm-transfer

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -285,8 +285,21 @@ public final class BankConfig {
     }
 
     // pos.info.lore-buyer
-    public @NotNull List<@NotNull String> posInfoLoreBuyer() {
-        return Objects.requireNonNull(config.getStringList("pos.info.lore-buyer"));
+    public @NotNull List<@NotNull Component> posInfoLoreBuyer(final @NotNull POS pos) {
+        return Objects.requireNonNull(config.getStringList("pos.info.lore-buyer")).stream().map(string -> MiniMessage.miniMessage().deserialize(
+                string,
+                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
+                Placeholder.unparsed("price", pos.price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price)),
+                Placeholder.unparsed("account", pos.seller.name()),
+                Placeholder.unparsed("account-id", pos.seller.id),
+                Placeholder.unparsed("account-type", pos.seller.type.getName()),
+                Placeholder.component("account-owner", pos.seller.ownerName()),
+                Placeholder.unparsed("balance", pos.seller.balance == null ? "∞" : pos.seller.balance.toPlainString()),
+                Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(pos.seller.balance)),
+                Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(pos.seller.balance))
+        ).decoration(TextDecoration.ITALIC, false)).toList();
     }
 
     // pos.delete.material

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -195,8 +195,15 @@ public final class BankConfig {
     }
 
     // instruments.lore
-    public @NotNull List<@NotNull String> instrumentsLore() {
-        return Objects.requireNonNull(config.getStringList("instruments.lore"));
+    public @NotNull List<@NotNull Component> instrumentsLore(final @NotNull Account account, final @NotNull TemporalAccessor created) {
+        return Objects.requireNonNull(config.getStringList("instruments.lore")).stream().map(string -> MiniMessage.miniMessage().deserialize(
+                string,
+                Placeholder.unparsed("account", account.name()),
+                Placeholder.unparsed("account-id", account.id),
+                Placeholder.unparsed("account-type", account.type.getName()),
+                Placeholder.component("account-owner", account.ownerName()),
+                Formatter.date("date", created)
+        )).toList();
     }
 
     // instruments.glint.enabled

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -937,8 +937,25 @@ public final class BankConfig {
     }
 
     // messages.pos-removed
-    public @NotNull String messagesPosCreated() {
-        return Objects.requireNonNull(config.getString("messages.pos-created"));
+    public @NotNull Component messagesPosCreated(final @NotNull POS pos) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.pos-created"))
+                        .replace("<account>", pos.seller.name())
+                        .replace("<account-id>", pos.seller.id)
+                        .replace("<account-type>", pos.seller.type.getName())
+                        .replace("<account-owner>", pos.seller.ownerNameUnparsed())
+                        .replace("<balance>", pos.seller.balance == null ? "∞" : pos.seller.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(pos.seller.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(pos.seller.balance))
+                        .replace("<price>", pos.price.toPlainString())
+                        .replace("<price-formatted>", BankAccounts.formatCurrency(pos.price))
+                        .replace("<price-short>", BankAccounts.formatCurrencyShort(pos.price))
+                        .replace("<description>", pos.description == null ? "<gray><i>no description</i></gray>" : pos.description)
+                        .replace("<x>", String.valueOf(pos.x))
+                        .replace("<y>", String.valueOf(pos.y))
+                        .replace("<z>", String.valueOf(pos.z))
+                        .replace("<world>", pos.world.getName())
+        );
     }
 
     // messages.pos-removed

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -409,8 +409,12 @@ public final class BankConfig {
     }
 
     // messages.command-usage
-    public @NotNull String messagesCommandUsage() {
-        return Objects.requireNonNull(config.getString("messages.command-usage"));
+    public @NotNull Component messagesCommandUsage(final @NotNull String command, final @NotNull String arguments) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.command-usage")),
+                Placeholder.unparsed("command", command),
+                Placeholder.unparsed("arguments", arguments)
+        );
     }
 
     // messages.types.

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -318,8 +318,8 @@ public final class BankConfig {
     }
 
     // pos.delete.lore
-    public @NotNull List<@NotNull String> posDeleteLore() {
-        return Objects.requireNonNull(config.getStringList("pos.delete.lore"));
+    public @NotNull List<@NotNull Component> posDeleteLore() {
+        return Objects.requireNonNull(config.getStringList("pos.delete.lore")).stream().map(string -> MiniMessage.miniMessage().deserialize(string).decoration(TextDecoration.ITALIC, false)).toList();
     }
 
     // pos.confirm.material

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -10,7 +10,9 @@ import org.bukkit.Registry;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
@@ -223,8 +225,14 @@ public final class BankConfig {
     }
 
     // pos.title
-    public @NotNull String posTitle() {
-        return Objects.requireNonNull(config.getString("pos.title"));
+    public @NotNull Component posTitle(final @Nullable String description, final @NotNull BigDecimal price) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("pos.title")),
+                Placeholder.unparsed("description", description == null ? "no description" : description),
+                Placeholder.unparsed("price", price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(price))
+        );
     }
 
     // pos.info.material

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -11,6 +11,7 @@ import org.bukkit.Registry;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -826,6 +827,7 @@ public final class BankConfig {
                         .replace("<amount-short>", BankAccounts.formatCurrencyShort(transaction.amount))
                         .replace("<description>", transaction.description == null ? "<gray><i>no description</i>" : transaction.description)
                         .replace("<transaction-id>", String.valueOf(transaction.getId()))
+                        .replace("<instrument>", transaction.instrument == null ? "direct transfer" : transaction.instrument)
         );
     }
 
@@ -852,6 +854,7 @@ public final class BankConfig {
                         .replace("<amount-short>", BankAccounts.formatCurrencyShort(transaction.amount))
                         .replace("<description>", transaction.description == null ? "<gray><i>no description</i>" : transaction.description)
                         .replace("<transaction-id>", String.valueOf(transaction.getId()))
+                        .replace("<instrument>", transaction.instrument == null ? "direct transfer" : transaction.instrument)
         );
     }
 
@@ -954,6 +957,7 @@ public final class BankConfig {
                         .replace("<x>", String.valueOf(pos.x))
                         .replace("<y>", String.valueOf(pos.y))
                         .replace("<z>", String.valueOf(pos.z))
+                        .replace("<pos>", "X: " + pos.x + " Y: " + pos.y + " Z: " + pos.z + " in " + pos.world.getName())
                         .replace("<world>", pos.world.getName())
         );
     }
@@ -964,13 +968,61 @@ public final class BankConfig {
     }
 
     // messages.pos-purchase
-    public @NotNull String messagesPosPurchase() {
-        return Objects.requireNonNull(config.getString("messages.pos-purchase"));
+    public @NotNull Component messagesPosPurchase(final @NotNull Transaction transaction, final @NotNull ItemStack @NotNull [] items) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.pos-purchase"))
+                        .replace("<from-account>", transaction.from.name())
+                        .replace("<from-account-id>", transaction.from.id)
+                        .replace("<from-account-type>", transaction.from.type.getName())
+                        .replace("<from-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<from-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<from-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<from-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<to-account>", transaction.from.name())
+                        .replace("<to-account-id>", transaction.from.id)
+                        .replace("<to-account-type>", transaction.from.type.getName())
+                        .replace("<to-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<to-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<to-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<to-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<amount>", transaction.amount.toPlainString())
+                        .replace("<amount-formatted>", BankAccounts.formatCurrency(transaction.amount))
+                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(transaction.amount))
+                        .replace("<description>", transaction.description == null ? "<gray><i>no description</i>" : transaction.description)
+                        .replace("<transaction-id>", String.valueOf(transaction.getId()))
+                        .replace("<instrument>", transaction.instrument == null ? "direct transfer" : transaction.instrument)
+                        .replace("<items>", String.valueOf(items.length))
+                        .replace("<items-formatted>", items.length == 1 ? "1 item" : items.length + " items")
+        );
     }
 
-    // messages.pos-purchase.seller
-    public @NotNull String messagesPosPurchaseSeller() {
-        return Objects.requireNonNull(config.getString("messages.pos-purchase.seller"));
+    // messages.pos-purchase-seller
+    public @NotNull Component messagesPosPurchaseSeller(final @NotNull Transaction transaction, final @NotNull ItemStack @NotNull [] items) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.pos-purchase-seller"))
+                        .replace("<from-account>", transaction.from.name())
+                        .replace("<from-account-id>", transaction.from.id)
+                        .replace("<from-account-type>", transaction.from.type.getName())
+                        .replace("<from-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<from-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<from-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<from-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<to-account>", transaction.from.name())
+                        .replace("<to-account-id>", transaction.from.id)
+                        .replace("<to-account-type>", transaction.from.type.getName())
+                        .replace("<to-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<to-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<to-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<to-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<amount>", transaction.amount.toPlainString())
+                        .replace("<amount-formatted>", BankAccounts.formatCurrency(transaction.amount))
+                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(transaction.amount))
+                        .replace("<description>", transaction.description == null ? "<gray><i>no description</i>" : transaction.description)
+                        .replace("<transaction-id>", String.valueOf(transaction.getId()))
+                        .replace("<instrument>", transaction.instrument == null ? "direct transfer" : transaction.instrument)
+                        .replace("<items>", String.valueOf(items.length))
+                        .replace("<items-formatted>", items.length == 1 ? "1 item" : items.length + " items")
+        );
     }
 
     // messages.whois

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -12,7 +12,9 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.HumanEntity;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.time.temporal.TemporalAccessor;
 import java.util.List;
@@ -773,18 +775,81 @@ public final class BankConfig {
     }
 
     // messages.confirm-transfer
-    public @NotNull String messagesConfirmTransfer() {
-        return Objects.requireNonNull(config.getString("messages.confirm-transfer"));
+    public @NotNull Component messagesConfirmTransfer(final @NotNull Account from, final @NotNull Account to, final @NotNull BigDecimal amount, final @Nullable String description) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.confirm-transfer"))
+                        .replace("<from-account>", from.name())
+                        .replace("<from-account-id>", from.id)
+                        .replace("<from-account-type>", from.type.getName())
+                        .replace("<from-account-owner>", from.ownerNameUnparsed())
+                        .replace("<from-balance>", from.balance == null ? "∞" : from.balance.toPlainString())
+                        .replace("<from-balance-formatted>", BankAccounts.formatCurrency(from.balance))
+                        .replace("<from-balance-short>", BankAccounts.formatCurrencyShort(from.balance))
+                        .replace("<to-account>", from.name())
+                        .replace("<to-account-id>", from.id)
+                        .replace("<to-account-type>", from.type.getName())
+                        .replace("<to-account-owner>", from.ownerNameUnparsed())
+                        .replace("<to-balance>", from.balance == null ? "∞" : from.balance.toPlainString())
+                        .replace("<to-balance-formatted>", BankAccounts.formatCurrency(from.balance))
+                        .replace("<to-balance-short>", BankAccounts.formatCurrencyShort(from.balance))
+                        .replace("<amount>", amount.toPlainString())
+                        .replace("<amount-formatted>", BankAccounts.formatCurrency(amount))
+                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(amount))
+                        .replace("<description>", description == null ? "<gray><i>no description</i>" : description)
+                        .replace("<confirm-command>", "/bank transfer --confirm " + from.id + " " + to.id + " " + amount.toPlainString() + (description == null ? "" : " " + description))
+        );
     }
 
     // messages.transfer-sent
-    public @NotNull String messagesTransferSent() {
-        return Objects.requireNonNull(config.getString("messages.transfer-sent"));
+    public @NotNull Component messagesTransferSent(final @NotNull Transaction transaction) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.transfer-sent"))
+                        .replace("<from-account>", transaction.from.name())
+                        .replace("<from-account-id>", transaction.from.id)
+                        .replace("<from-account-type>", transaction.from.type.getName())
+                        .replace("<from-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<from-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<from-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<from-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<to-account>", transaction.from.name())
+                        .replace("<to-account-id>", transaction.from.id)
+                        .replace("<to-account-type>", transaction.from.type.getName())
+                        .replace("<to-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<to-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<to-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<to-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<amount>", transaction.amount.toPlainString())
+                        .replace("<amount-formatted>", BankAccounts.formatCurrency(transaction.amount))
+                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(transaction.amount))
+                        .replace("<description>", transaction.description == null ? "<gray><i>no description</i>" : transaction.description)
+                        .replace("<transaction-id>", String.valueOf(transaction.getId()))
+        );
     }
 
     // messages.transfer-received
-    public @NotNull String messagesTransferReceived() {
-        return Objects.requireNonNull(config.getString("messages.transfer-received"));
+    public @NotNull Component messagesTransferReceived(final @NotNull Transaction transaction) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.transfer-received"))
+                        .replace("<from-account>", transaction.from.name())
+                        .replace("<from-account-id>", transaction.from.id)
+                        .replace("<from-account-type>", transaction.from.type.getName())
+                        .replace("<from-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<from-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<from-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<from-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<to-account>", transaction.from.name())
+                        .replace("<to-account-id>", transaction.from.id)
+                        .replace("<to-account-type>", transaction.from.type.getName())
+                        .replace("<to-account-owner>", transaction.from.ownerNameUnparsed())
+                        .replace("<to-balance>", transaction.from.balance == null ? "∞" : transaction.from.balance.toPlainString())
+                        .replace("<to-balance-formatted>", BankAccounts.formatCurrency(transaction.from.balance))
+                        .replace("<to-balance-short>", BankAccounts.formatCurrencyShort(transaction.from.balance))
+                        .replace("<amount>", transaction.amount.toPlainString())
+                        .replace("<amount-formatted>", BankAccounts.formatCurrency(transaction.amount))
+                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(transaction.amount))
+                        .replace("<description>", transaction.description == null ? "<gray><i>no description</i>" : transaction.description)
+                        .replace("<transaction-id>", String.valueOf(transaction.getId()))
+        );
     }
 
     // messages.history.header

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -183,7 +183,7 @@ public final class BankConfig {
     }
 
     // instruments.material
-    public final @NotNull Material instrumentsMaterial() {
+    public @NotNull Material instrumentsMaterial() {
         return Objects.requireNonNull(Material.getMaterial(Objects.requireNonNull(config.getString("instruments.material"))));
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -959,8 +959,8 @@ public final class BankConfig {
     }
 
     // messages.pos-removed
-    public @NotNull String messagesPosRemoved() {
-        return Objects.requireNonNull(config.getString("messages.pos-removed"));
+    public @NotNull Component messagesPosRemoved() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.pos-removed")));
     }
 
     // messages.pos-purchase

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -665,13 +665,22 @@ public final class BankConfig {
     }
 
     // messages.list-accounts.header
-    public @NotNull String messagesListAccountsHeader() {
-        return Objects.requireNonNull(config.getString("messages.list-accounts.header"));
+    public @NotNull Component messagesListAccountsHeader() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.list-accounts.header")));
     }
 
     // messages.list-accounts.entry
-    public @NotNull String messagesListAccountsEntry() {
-        return Objects.requireNonNull(config.getString("messages.list-accounts.entry"));
+    public @NotNull Component messagesListAccountsEntry(final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.list-accounts.entry"))
+                        .replace("<account>", account.name())
+                        .replace("<account-id>", account.id)
+                        .replace("<account-type>", account.type.getName())
+                        .replace("<account-owner>", account.ownerNameUnparsed())
+                        .replace("<balance>", account.balance == null ? "∞" : account.balance.toPlainString())
+                        .replace("<balance-formatted>", BankAccounts.formatCurrency(account.balance))
+                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(account.balance))
+        );
     }
 
     // messages.reload

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -1,6 +1,7 @@
 package pro.cloudnode.smp.bankaccounts;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -246,8 +247,14 @@ public final class BankConfig {
     }
 
     // pos.info.name-owner
-    public @NotNull String posInfoNameOwner() {
-        return Objects.requireNonNull(config.getString("pos.info.name-owner"));
+    public @NotNull Component posInfoNameOwner(final @Nullable String description, final @NotNull BigDecimal price) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("pos.info.name-owner")),
+                Placeholder.unparsed("description", description == null ? "no description" : description),
+                Placeholder.unparsed("price", price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(price))
+        ).decoration(TextDecoration.ITALIC, false);
     }
 
     // pos.info.name-buyer

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.jetbrains.annotations.NotNull;
@@ -213,7 +214,7 @@ public final class BankConfig {
 
     // instruments.glint.enchantment
     public @NotNull Enchantment instrumentsGlintEnchantment() {
-        return Objects.requireNonNull(Enchantment.getByKey(NamespacedKey.minecraft(Objects.requireNonNull(config.getString("instruments.glint.enchantment")))));
+        return Objects.requireNonNull(Registry.ENCHANTMENT.get(NamespacedKey.minecraft(Objects.requireNonNull(config.getString("instruments.glint.enchantment")))));
     }
 
     // pos.allow-personal

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -927,8 +927,8 @@ public final class BankConfig {
     }
 
     // messages.history.no-transactions
-    public @NotNull String messagesHistoryNoTransactions() {
-        return Objects.requireNonNull(config.getString("messages.history.no-transactions"));
+    public @NotNull Component messagesHistoryNoTransactions() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.history.no-transactions")));
     }
 
     // messages.instrument-created

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -347,7 +347,7 @@ public final class BankConfig {
                 Placeholder.unparsed("balance", buyer.balance == null ? "∞" : buyer.balance.toPlainString()),
                 Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(buyer.balance)),
                 Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(buyer.balance))
-        );
+        ).decoration(TextDecoration.ITALIC, false);
     }
 
     // pos.confirm.lore
@@ -365,7 +365,7 @@ public final class BankConfig {
             Placeholder.unparsed("balance", buyer.balance == null ? "∞" : buyer.balance.toPlainString()),
             Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(buyer.balance)),
             Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(buyer.balance))
-        )).toList();
+        ).decoration(TextDecoration.ITALIC, false)).toList();
     }
 
     // pos.decline.material

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -379,8 +379,8 @@ public final class BankConfig {
     }
 
     // pos.decline.name
-    public @NotNull String posDeclineName() {
-        return Objects.requireNonNull(config.getString("pos.decline.name"));
+    public @NotNull Component posDeclineName() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("pos.decline.name"))).decoration(TextDecoration.ITALIC, false);
     }
 
     // pos.decline.lore

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -1083,7 +1083,10 @@ public final class BankConfig {
     }
 
     // messages.update-available
-    public @NotNull String messagesUpdateAvailable() {
-        return Objects.requireNonNull(config.getString("messages.update-available"));
+    public @NotNull Component messagesUpdateAvailable(final @NotNull String version) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("messages.update-available"))
+                        .replace("<version>", version)
+        );
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -1,5 +1,9 @@
 package pro.cloudnode.smp.bankaccounts;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -7,6 +11,7 @@ import org.bukkit.enchantments.Enchantment;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.DecimalFormat;
+import java.time.temporal.TemporalAccessor;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -178,8 +183,15 @@ public final class BankConfig {
     }
 
     // instruments.name
-    public @NotNull String instrumentsName() {
-        return Objects.requireNonNull(config.getString("instruments.name"));
+    public @NotNull Component instrumentsName(final @NotNull Account account, final @NotNull TemporalAccessor created) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("instruments.name")),
+                Placeholder.unparsed("account", account.name()),
+                Placeholder.unparsed("account-id", account.id),
+                Placeholder.unparsed("account-type", account.type.getName()),
+                Placeholder.component("account-owner", account.ownerName()),
+                Formatter.date("date", created)
+        );
     }
 
     // instruments.lore

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -932,8 +932,8 @@ public final class BankConfig {
     }
 
     // messages.instrument-created
-    public @NotNull String messagesInstrumentCreated() {
-        return Objects.requireNonNull(config.getString("messages.instrument-created"));
+    public @NotNull Component messagesInstrumentCreated() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.instrument-created")));
     }
 
     // messages.pos-removed

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -258,8 +258,21 @@ public final class BankConfig {
     }
 
     // pos.info.name-buyer
-    public @NotNull String posInfoNameBuyer() {
-        return Objects.requireNonNull(config.getString("pos.info.name-buyer"));
+    public @NotNull Component posInfoNameBuyer(final @Nullable String description, final @NotNull BigDecimal price, final @NotNull Account account) {
+        return MiniMessage.miniMessage().deserialize(
+                Objects.requireNonNull(config.getString("pos.info.name-buyer")),
+                Placeholder.unparsed("description", description == null ? "no description" : description),
+                Placeholder.unparsed("price", price.toPlainString()),
+                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(price)),
+                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(price)),
+                Placeholder.unparsed("account", account.name()),
+                Placeholder.unparsed("account-id", account.id),
+                Placeholder.unparsed("account-type", account.type.getName()),
+                Placeholder.component("account-owner", account.ownerName()),
+                Placeholder.unparsed("balance", account.balance == null ? "∞" : account.balance.toPlainString()),
+                Placeholder.unparsed("balance-formatted", BankAccounts.formatCurrency(account.balance)),
+                Placeholder.unparsed("balance-short", BankAccounts.formatCurrencyShort(account.balance))
+        ).decoration(TextDecoration.ITALIC, false);
     }
 
     // pos.info.lore-owner

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -2,7 +2,6 @@ package pro.cloudnode.smp.bankaccounts;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -48,7 +47,7 @@ public abstract class Command implements CommandExecutor, TabCompleter {
      * @return Always true.
      */
     protected static boolean sendUsage(final @NotNull CommandSender sender, final @NotNull String label, final @NotNull String arguments) {
-        return sendMessage(sender, BankAccounts.getInstance().config().messagesCommandUsage(), Placeholder.unparsed("command", label), Placeholder.unparsed("arguments", arguments));
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesCommandUsage(label, arguments));
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -351,12 +351,7 @@ public final class POS {
             overview.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
-        overviewMeta.displayName(MiniMessage.miniMessage().deserialize(Account.placeholdersString(BankAccounts.getInstance().config().posInfoNameBuyer(), pos.seller),
-                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                Placeholder.unparsed("price", pos.price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-        ).decoration(TextDecoration.ITALIC, false));
+        overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameBuyer(pos.description, pos.price, pos.seller));
         overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreBuyer().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, pos.seller),
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -359,13 +359,7 @@ public final class POS {
         }
         final @NotNull ItemMeta confirmMeta = confirm.getItemMeta();
         confirmMeta.displayName(BankAccounts.getInstance().config().posConfirmName(pos, account));
-        confirmMeta.lore(BankAccounts.getInstance().config().posConfirmLore().stream()
-                .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, account),
-                        Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                        Placeholder.unparsed("price", pos.price.toPlainString()),
-                        Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                        Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-                ).decoration(TextDecoration.ITALIC, false)).collect(Collectors.toList()));
+        confirmMeta.lore(BankAccounts.getInstance().config().posConfirmLore(pos, account));
         final @NotNull PersistentDataContainer confirmContainer = confirmMeta.getPersistentDataContainer();
         confirmContainer.set(BankAccounts.Key.POS_BUYER_GUI_CONFIRM, PersistentDataType.STRING, account.id);
         confirm.setItemMeta(confirmMeta);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -346,13 +346,7 @@ public final class POS {
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
         overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameBuyer(pos));
-        overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreBuyer().stream()
-                .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, pos.seller),
-                        Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                        Placeholder.unparsed("price", pos.price.toPlainString()),
-                        Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                        Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-                ).decoration(TextDecoration.ITALIC, false)).collect(Collectors.toList()));
+        overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreBuyer(pos));
         final @NotNull PersistentDataContainer overviewContainer = overviewMeta.getPersistentDataContainer();
         overviewContainer.set(BankAccounts.Key.POS_BUYER_GUI, PersistentDataType.STRING, String.join(",", POS.checksum(items)));
         overview.setItemMeta(overviewMeta);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -300,12 +300,7 @@ public final class POS {
             overview.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
-        overviewMeta.displayName(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posInfoNameOwner(),
-                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                Placeholder.unparsed("price", pos.price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-        ).decoration(TextDecoration.ITALIC, false));
+        overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameOwner(pos.description, pos.price));
         overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreOwner().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(line,
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -311,7 +311,7 @@ public final class POS {
             delete.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta deleteMeta = delete.getItemMeta();
-        deleteMeta.displayName(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posDeleteName()).decoration(TextDecoration.ITALIC, false));
+        deleteMeta.displayName(BankAccounts.getInstance().config().posDeleteName());
         deleteMeta.lore(BankAccounts.getInstance().config().posDeleteLore().stream().map(line -> MiniMessage.miniMessage().deserialize(line)).collect(Collectors.toList()));
         final @NotNull PersistentDataContainer deleteContainer = deleteMeta.getPersistentDataContainer();
         deleteContainer.set(BankAccounts.Key.POS_OWNER_GUI, PersistentDataType.STRING, pos.id());

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -371,7 +371,7 @@ public final class POS {
             cancel.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta cancelMeta = cancel.getItemMeta();
-        cancelMeta.displayName(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posDeclineName()).decoration(TextDecoration.ITALIC, false));
+        cancelMeta.displayName(BankAccounts.getInstance().config().posDeclineName());
         cancelMeta.lore(BankAccounts.getInstance().config().posDeclineLore().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, account),
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -358,12 +358,7 @@ public final class POS {
             confirm.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta confirmMeta = confirm.getItemMeta();
-        confirmMeta.displayName(MiniMessage.miniMessage().deserialize(Account.placeholdersString(BankAccounts.getInstance().config().posConfirmName(), account),
-                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                Placeholder.unparsed("price", pos.price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-        ).decoration(TextDecoration.ITALIC, false));
+        confirmMeta.displayName(BankAccounts.getInstance().config().posConfirmName(pos, account));
         confirmMeta.lore(BankAccounts.getInstance().config().posConfirmLore().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, account),
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -291,7 +291,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos.description, pos.price));
+        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);
@@ -300,7 +300,7 @@ public final class POS {
             overview.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
-        overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameOwner(pos.description, pos.price));
+        overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameOwner(pos));
         overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreOwner().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(line,
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
@@ -342,7 +342,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos.description, pos.price));
+        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);
@@ -351,7 +351,7 @@ public final class POS {
             overview.addUnsafeEnchantment(Enchantment.ARROW_INFINITE, 1);
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
-        overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameBuyer(pos.description, pos.price, pos.seller));
+        overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameBuyer(pos));
         overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreBuyer().stream()
                 .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, pos.seller),
                         Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -1,8 +1,5 @@
 package pro.cloudnode.smp.bankaccounts;
 
-import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -33,7 +30,6 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.zip.CRC32;
 
@@ -372,13 +368,7 @@ public final class POS {
         }
         final @NotNull ItemMeta cancelMeta = cancel.getItemMeta();
         cancelMeta.displayName(BankAccounts.getInstance().config().posDeclineName());
-        cancelMeta.lore(BankAccounts.getInstance().config().posDeclineLore().stream()
-                .map(line -> MiniMessage.miniMessage().deserialize(Account.placeholdersString(line, account),
-                        Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                        Placeholder.unparsed("price", pos.price.toPlainString()),
-                        Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                        Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-                ).decoration(TextDecoration.ITALIC, false)).collect(Collectors.toList()));
+        cancelMeta.lore(BankAccounts.getInstance().config().posDeclineLore());
         final @NotNull PersistentDataContainer cancelContainer = cancelMeta.getPersistentDataContainer();
         cancelContainer.set(BankAccounts.Key.POS_BUYER_GUI_CANCEL, PersistentDataType.STRING, pos.id());
         cancel.setItemMeta(cancelMeta);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -67,30 +67,6 @@ public final class POS {
      */
     public final @NotNull Date created;
 
-
-    /**
-     * Create new POS instance
-     *
-     * @param x           POS X coordinate
-     * @param y           POS Y coordinate
-     * @param z           POS Z coordinate
-     * @param world       POS world
-     * @param price       Price of POS contents
-     * @param description Description that appears on the bank statement
-     * @param seller      Account that receives the money from the sale
-     * @param created     Date the POS was created
-     */
-    public POS(final int x, final int y, final int z, final @NotNull World world, final @NotNull BigDecimal price, final @Nullable String description, final @NotNull Account seller, final @NotNull Date created) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-        this.world = world;
-        this.price = price;
-        this.description = description;
-        this.seller = seller;
-        this.created = created;
-    }
-
     /**
      * Create new POS instance
      *

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -312,7 +312,7 @@ public final class POS {
         }
         final @NotNull ItemMeta deleteMeta = delete.getItemMeta();
         deleteMeta.displayName(BankAccounts.getInstance().config().posDeleteName());
-        deleteMeta.lore(BankAccounts.getInstance().config().posDeleteLore().stream().map(line -> MiniMessage.miniMessage().deserialize(line)).collect(Collectors.toList()));
+        deleteMeta.lore(BankAccounts.getInstance().config().posDeleteLore());
         final @NotNull PersistentDataContainer deleteContainer = deleteMeta.getPersistentDataContainer();
         deleteContainer.set(BankAccounts.Key.POS_OWNER_GUI, PersistentDataType.STRING, pos.id());
         delete.setItemMeta(deleteMeta);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -291,12 +291,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posTitle(),
-                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                Placeholder.unparsed("price", pos.price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-        ));
+        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos.description, pos.price));
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);
@@ -352,12 +347,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().posTitle(),
-                Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                Placeholder.unparsed("price", pos.price.toPlainString()),
-                Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-        ));
+        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos.description, pos.price));
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -301,13 +301,7 @@ public final class POS {
         }
         final @NotNull ItemMeta overviewMeta = overview.getItemMeta();
         overviewMeta.displayName(BankAccounts.getInstance().config().posInfoNameOwner(pos));
-        overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreOwner().stream()
-                .map(line -> MiniMessage.miniMessage().deserialize(line,
-                        Placeholder.unparsed("description", pos.description == null ? "no description" : pos.description),
-                        Placeholder.unparsed("price", pos.price.toPlainString()),
-                        Placeholder.unparsed("price-formatted", BankAccounts.formatCurrency(pos.price)),
-                        Placeholder.unparsed("price-short", BankAccounts.formatCurrencyShort(pos.price))
-                ).decoration(TextDecoration.ITALIC, false)).collect(Collectors.toList()));
+        overviewMeta.lore(BankAccounts.getInstance().config().posInfoLoreOwner(pos));
         overview.setItemMeta(overviewMeta);
         gui.setItem(size - 5, overview);
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Transaction.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Transaction.java
@@ -12,7 +12,6 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Level;
 
 /**
@@ -95,7 +94,7 @@ public class Transaction {
      * Create a new transaction from a database result set
      * @param rs Result set
      */
-    public Transaction(ResultSet rs) throws SQLException, Exception {
+    public Transaction(ResultSet rs) throws SQLException {
         this(rs.getInt("id"), Account.get(rs.getString("from")).orElse(new Account.ClosedAccount()), Account.get(rs.getString("to")).orElse(new Account.ClosedAccount()), rs.getBigDecimal("amount"), rs.getTimestamp("time"), rs.getString("description"), rs.getString("instrument"));
     }
 
@@ -119,22 +118,6 @@ public class Transaction {
             if (rs.next()) this.id = rs.getInt(1);
         } catch (Exception e) {
             BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not save transaction: " + this.id, e);
-        }
-    }
-
-    /**
-     * Get transaction by ID
-     * @param id Transaction ID
-     */
-    public static Optional<Transaction> get(int id) {
-        try (Connection conn = BankAccounts.getInstance().getDb().getConnection();
-             PreparedStatement stmt = conn.prepareStatement("SELECT * FROM `bank_transactions` WHERE `id` = ? LIMIT 1")) {
-            stmt.setInt(1, id);
-            ResultSet rs = stmt.executeQuery();
-            return rs.next() ? Optional.of(new Transaction(rs)) : Optional.empty();
-        } catch (Exception e) {
-            BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not get transaction: " + id, e);
-            return Optional.empty();
         }
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Transaction.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Transaction.java
@@ -1,8 +1,5 @@
 package pro.cloudnode.smp.bankaccounts;
 
-import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
-
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -14,7 +11,6 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -200,32 +196,5 @@ public class Transaction {
             BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not count transactions of account: " + account.id, e);
             return 0;
         }
-    }
-
-
-
-    /**
-     * Transactions message placeholders
-     * <ul>
-     *     <li>{@code <transaction-id>} Transaction ID</li>
-     *     <li>{@code <amount>} Transfer amount without formatting, example: 123456.78</li>
-     *     <li>{@code <amount-formatted>} Transfer amount with formatting, example: 123,456.78</li>
-     *     <li>{@code <amount-short>} Transfer amount with formatting, example: 123k</li>
-     *     <li>{@code <description>} Transfer description</li>
-     * </ul>
-     * @param transaction Transaction
-     * @param message Message to replace placeholders in
-     */
-    public static Component placeholders(@NotNull Transaction transaction, @NotNull String message) {
-        return Account.placeholders(message
-                        .replace("<transaction-id>", String.valueOf(transaction.getId()))
-                        .replace("<amount>", transaction.amount.toPlainString())
-                        .replace("<amount-formatted>", BankAccounts.formatCurrency(transaction.amount))
-                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(transaction.amount))
-                        .replace("<description>", transaction.description == null ? "<gray><i>no description</i></gray>" : transaction.description),
-                new HashMap<>() {{
-                    put("from", transaction.from);
-                    put("to", transaction.to);
-                }});
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Transaction.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Transaction.java
@@ -1,8 +1,6 @@
 package pro.cloudnode.smp.bankaccounts;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -14,14 +12,11 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.text.SimpleDateFormat;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.logging.Level;
 
 /**
@@ -232,33 +227,5 @@ public class Transaction {
                     put("from", transaction.from);
                     put("to", transaction.to);
                 }});
-    }
-
-
-    /**
-     * Transaction placeholders
-     * @param transaction Transaction
-     * @param account Account
-     * @param message Message to replace placeholders in
-     */
-    public static Component historyPlaceholders(@NotNull Transaction transaction, @NotNull Account account, @NotNull String message) {
-        final SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy HH:mm:ss");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        boolean isSender = transaction.from.id.equals(account.id);
-        final BigDecimal amount = isSender ? transaction.amount.negate() : transaction.amount;
-        final Account other = isSender ? transaction.to : transaction.from;
-        message = message
-                .replace("<amount>", amount.toPlainString())
-                .replace("<amount-formatted>", BankAccounts.formatCurrency(amount))
-                .replace("<amount-short>", BankAccounts.formatCurrencyShort(amount))
-                .replace("<description>", transaction.description == null ? "<gray><i>no description</i></gray>" : transaction.description)
-                .replace("<transaction-id>", String.valueOf(transaction.getId()))
-                .replace("<instrument>", transaction.instrument == null ? "direct transfer" : transaction.instrument)
-                .replace("<full_date>", sdf.format(transaction.time) + " UTC");
-        message = Account.placeholdersString(message, new HashMap<>() {{
-            put("", account);
-            put("other", other);
-        }});
-        return MiniMessage.miniMessage().deserialize(message, Formatter.date("date", transaction.time.toInstant().atZone(ZoneOffset.UTC).toLocalDateTime()));
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BaltopCommand.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts.commands;
 
-import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,8 +42,6 @@ public final class BaltopCommand extends Command {
         if (page < 1) page = 1;
         final int perPage = BankAccounts.getInstance().config().baltopPerPage();
 
-        final @NotNull String labelArgsString = labelArgs.length > 0 ? " " + String.join(" ", labelArgs) : "";
-        final @NotNull String argsString = (args.length > 0 ? " " + String.join(" ", args) : "");
         final @NotNull String cmdPrev = "/baltop" + (type.map(s -> " " + s).orElse("")) + " " + Math.max(1, page - 1);
         final @NotNull String cmdNext = "/baltop" + (type.map(s -> " " + s).orElse("")) + " " + Math.min(1000000000, page + 1);
 
@@ -52,36 +49,17 @@ public final class BaltopCommand extends Command {
         if (accountType != null || type.isEmpty()) {
             final @NotNull String category = accountType != null ? BankAccounts.getInstance().config().messagesTypes(accountType) : "All";
             final @NotNull Account @NotNull [] accounts = Account.getTopBalance(perPage, page, accountType);
-            sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopHeader()
-                    .replace("<category>", category)
-                    .replace("<page>", String.valueOf(page))
-                    .replace("<cmd-prev>", cmdPrev)
-                    .replace("<cmd-next>", cmdNext));
-            for (int i = 0; i < accounts.length; i++) {
+            sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopHeader(category, page, cmdPrev, cmdNext));
+            for (int i = 0; i < accounts.length; ++i) {
                 final @NotNull Account account = accounts[i];
-                sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBaltopEntry()
-                        .replace("<position>", String.valueOf((page - 1) * perPage + i + 1)), account));
+                sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopEntry(account, (page - 1) * perPage + i + 1));
             }
         }
         else {
-            sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopHeader()
-                    .replace("<category>", "Players")
-                    .replace("<page>", String.valueOf(page))
-                    .replace("<cmd-prev>", cmdPrev)
-                    .replace("<cmd-next>", cmdNext));
+            sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopHeader("Players", page, cmdPrev, cmdNext));
             final @NotNull BaltopPlayer @NotNull [] players = BaltopPlayer.get(perPage, page);
-            for (int i = 0; i < players.length; i++) {
-                final @NotNull BaltopPlayer entry = players[i];
-                final @NotNull OfflinePlayer player = BankAccounts.getInstance().getServer().getOfflinePlayer(entry.uuid);
-                sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopEntryPlayer()
-                        .replace("<position>", String.valueOf((page - 1) * perPage + i + 1))
-                        .replace("<uuid>", entry.uuid.toString())
-                        .replace("<username>", entry.uuid.toString().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId().toString()) ? "the Server" : Optional.ofNullable(player.getName()).orElse("Unknown Player"))
-                        .replace("<balance>", entry.balance.toPlainString())
-                        .replace("<balance-formatted>", BankAccounts.formatCurrency(entry.balance))
-                        .replace("<balance-short>", BankAccounts.formatCurrencyShort(entry.balance))
-                );
-            }
+            for (int i = 0; i < players.length; ++i)
+                sendMessage(sender, BankAccounts.getInstance().config().messagesBaltopEntryPlayer(players[i], (page - 1) * perPage + i + 1));
         }
         return true;
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -334,7 +334,7 @@ public class BankCommand extends Command {
         final @NotNull Account account = new Account(target, optionalType.get(), null, BigDecimal.ZERO, false);
         account.insert();
 
-        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountCreated(), account));
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesAccountCreated(account));
     }
 
     /**
@@ -358,7 +358,7 @@ public class BankCommand extends Command {
             }
             account.get().balance = balance;
             account.get().update();
-            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBalanceSet(), account.get()));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesBalanceSet(account.get()));
         }
     }
 
@@ -387,8 +387,7 @@ public class BankCommand extends Command {
 
             account.get().name = name;
             account.get().update();
-            return sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance()
-                    .config().messagesNameSet()), account.get()));
+            return sendMessage(sender, Objects.requireNonNull(BankAccounts.getInstance().config().messagesNameSet(account.get())));
         }
     }
 
@@ -404,7 +403,7 @@ public class BankCommand extends Command {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAlreadyFrozen(account.get()));
         account.get().frozen = true;
         account.get().update();
-        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountFrozen(), account.get()));
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesAccountFrozen(account.get()));
     }
 
     public static boolean unfreeze(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
@@ -419,7 +418,7 @@ public class BankCommand extends Command {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotFrozen(account.get()));
         account.get().frozen = false;
         account.get().update();
-        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountUnfrozen(), account.get()));
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesAccountUnfrozen(account.get()));
     }
 
     /**
@@ -442,7 +441,7 @@ public class BankCommand extends Command {
                 .preventCloseLastPersonal() && account.get().type == Account.Type.PERSONAL && !sender.hasPermission(Permissions.DELETE_PERSONAL) && Account.get(account.get().owner, Account.Type.PERSONAL).length == 1)
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsClosingPersonal());
         account.get().delete();
-        return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesAccountDeleted(), account.get()));
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesAccountDeleted(account.get()));
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -280,8 +280,8 @@ public class BankCommand extends Command {
         else {
             sendMessage(sender, BankAccounts.getInstance().config().messagesListAccountsHeader());
             for (final @NotNull Account account : accounts)
-                sendMessage(sender, Account.placeholders(Objects.requireNonNull(BankAccounts.getInstance().config()
-                        .messagesListAccountsEntry()), account));
+                sendMessage(sender, Objects.requireNonNull(BankAccounts.getInstance().config()
+                        .messagesListAccountsEntry(account)));
         }
         return true;
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -268,7 +268,7 @@ public class BankCommand extends Command {
             else if (!sender.hasPermission(Permissions.BALANCE_OTHER) && !account.get().owner.getUniqueId()
                     .equals((BankAccounts.getOfflinePlayer(sender)).getUniqueId()))
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
-            else return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBalance(), account.get()));
+            else return sendMessage(sender, BankAccounts.getInstance().config().messagesBalance(account.get()));
         }
     }
 
@@ -276,7 +276,7 @@ public class BankCommand extends Command {
         final @NotNull Account @NotNull [] accounts = Account.get(player);
         if (accounts.length == 0) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNoAccounts());
         else if (accounts.length == 1)
-            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesBalance(), accounts[0]));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesBalance(accounts[0]));
         else {
             sendMessage(sender, BankAccounts.getInstance().config().messagesListAccountsHeader());
             for (final @NotNull Account account : accounts)

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -623,7 +623,7 @@ public class BankCommand extends Command {
         if (args.length < 1) return sendUsage(sender, label, "whois <account>");
         final @NotNull Optional<@NotNull Account> account = Account.get(args[0]);
         return account
-                .map(value -> sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesWhois(), value)))
+                .map(value -> sendMessage(sender, BankAccounts.getInstance().config().messagesWhois(value)))
                 .orElseGet(() -> sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAccountNotFound()));
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -630,20 +630,4 @@ public class BankCommand extends Command {
     public static boolean baltop(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
         return BaltopCommand.run(sender, label, args, new String[]{"baltop"});
     }
-
-    /**
-     * Send transaction history header or footer
-     *
-     * @param sender  Command sender
-     * @param account Account
-     * @param page    Current page
-     * @param maxPage Maximum page
-     * @param message Message to replace placeholders in
-     */
-    public static void transactionsHeaderFooter(final @NotNull CommandSender sender, final @NotNull Account account, final int page, final int maxPage, final @NotNull String message) {
-        sender.sendMessage(Account.placeholders(message.replace("<page>", String.valueOf(page))
-                .replace("<max-page>", String.valueOf(maxPage))
-                .replace("<cmd-prev>", "/bank transactions " + account.id + " " + (page - 1))
-                .replace("<cmd-next>", "/bank transactions " + account.id + " " + (page + 1)), account));
-    }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -560,10 +560,10 @@ public class BankCommand extends Command {
         else {
             final int count = Transaction.count(account.get());
             final int maxPage = (int) Math.ceil((double) count / limit.orElse(count));
-            transactionsHeaderFooter(sender, account.get(), page, maxPage, BankAccounts.getInstance().config().messagesHistoryHeader());
+            sendMessage(sender, BankAccounts.getInstance().config().messagesHistoryHeader(account.get(), page, maxPage));
             for (final @NotNull Transaction transaction : transactions)
                 sendMessage(sender, Transaction.historyPlaceholders(transaction, account.get(), BankAccounts.getInstance().config().messagesHistoryEntry()));
-            transactionsHeaderFooter(sender, account.get(), page, maxPage, BankAccounts.getInstance().config().messagesHistoryFooter());
+            sendMessage(sender, BankAccounts.getInstance().config().messagesHistoryFooter(account.get(), page, maxPage));
         }
         return true;
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -562,7 +562,7 @@ public class BankCommand extends Command {
             final int maxPage = (int) Math.ceil((double) count / limit.orElse(count));
             sendMessage(sender, BankAccounts.getInstance().config().messagesHistoryHeader(account.get(), page, maxPage));
             for (final @NotNull Transaction transaction : transactions)
-                sendMessage(sender, Transaction.historyPlaceholders(transaction, account.get(), BankAccounts.getInstance().config().messagesHistoryEntry()));
+                sendMessage(sender, BankAccounts.getInstance().config().messagesHistoryEntry(transaction, account.get()));
             sendMessage(sender, BankAccounts.getInstance().config().messagesHistoryFooter(account.get(), page, maxPage));
         }
         return true;

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -1,7 +1,6 @@
 package pro.cloudnode.smp.bankaccounts.commands;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.command.CommandSender;
@@ -47,7 +46,7 @@ public final class POSCommand extends Command {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosCreateBusinessOnly());
 
         if (account.get().frozen)
-            return sendMessage(sender, Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), account.get()));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsFrozen(account.get()));
 
         if (!player.hasPermission(Permissions.POS_CREATE_OTHER) && !account.get().owner.equals(player))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
@@ -57,11 +56,11 @@ public final class POSCommand extends Command {
             price = BigDecimal.valueOf(Double.parseDouble(args[1])).setScale(2, RoundingMode.HALF_UP);
         }
         catch (final @NotNull NumberFormatException e) {
-            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(), Placeholder.unparsed("number", args[1]));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(args[1]));
         }
 
         if (price.compareTo(BigDecimal.ZERO) <= 0)
-            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(), Placeholder.unparsed("number", args[1]));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(args[1]));
 
 
         final @Nullable Block target = player.getTargetBlockExact(5);
@@ -78,7 +77,7 @@ public final class POSCommand extends Command {
         if (description != null && description.length() > 64) description = description.substring(0, 64);
 
         if (description != null && (description.contains("<") || description.contains(">")))
-            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(), Placeholder.unparsed("characters", "<>"));
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters("<>"));
 
         final @NotNull POS pos = new POS(target.getLocation(), price, description, account.get(), new Date());
         pos.save();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts.commands;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.command.CommandSender;
@@ -81,7 +80,7 @@ public final class POSCommand extends Command {
 
         final @NotNull POS pos = new POS(target.getLocation(), price, description, account.get(), new Date());
         pos.save();
-        return sendMessage(sender, replacePlaceholders(BankAccounts.getInstance().config().messagesPosCreated(), pos));
+        return sendMessage(sender, BankAccounts.getInstance().config().messagesPosCreated(pos));
     }
 
     @Override
@@ -96,18 +95,5 @@ public final class POSCommand extends Command {
             }
         }
         return suggestions;
-    }
-
-    /**
-     * Replace POS placeholders
-     *
-     * @param message Message to replace placeholders in
-     * @param pos     POS to get placeholders from
-     */
-    public static @NotNull Component replacePlaceholders(final @NotNull String message, final @NotNull POS pos) {
-        return Account.placeholders(message.replace("<price>", pos.price.toPlainString())
-                .replace("<price-formatted>", BankAccounts.formatCurrency(pos.price))
-                .replace("<price-short>", BankAccounts.formatCurrencyShort(pos.price))
-                .replace("<description>", pos.description == null ? "<gray><i>no description</i></gray>" : pos.description), pos.seller);
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts.events;
 
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
@@ -25,7 +24,7 @@ public final class BlockBreak implements Listener {
                     final @NotNull Optional<POS> pos = POS.get(chest);
                     if (pos.isPresent()) {
                         pos.get().delete();
-                        event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesPosRemoved()));
+                        event.getPlayer().sendMessage(BankAccounts.getInstance().config().messagesPosRemoved());
                     }
                 });
             }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts.events;
 
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
@@ -55,7 +54,7 @@ public class GUI implements Listener {
                 }
                 if (event.getCurrentItem() != null && event.getCurrentItem().equals(item)) {
                     pos.get().delete();
-                    event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesPosRemoved()));
+                    event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesPosRemoved());
                     inventory.close();
                 }
             }
@@ -110,7 +109,7 @@ public class GUI implements Listener {
                         final @Nullable Player seller = pos.get().seller.owner.getPlayer();
                         if (seller != null) {
                             seller.sendMessage(BankAccounts.getInstance().config().messagesErrorsFrozen(pos.get().seller));
-                            seller.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesPosRemoved()));
+                            seller.sendMessage(BankAccounts.getInstance().config().messagesPosRemoved());
                         }
                         pos.get().delete();
                         return;

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -1,7 +1,6 @@
 package pro.cloudnode.smp.bankaccounts.events;
 
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
@@ -84,9 +83,9 @@ public class GUI implements Listener {
                 Block block = pos.get().getBlock();
                 if (!(block.getState() instanceof final @NotNull Chest chest)) {
                     inventory.close();
-                    event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosEmpty()));
+                    event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesErrorsPosEmpty());
                     final @Nullable Player seller = pos.get().seller.owner.getPlayer();
-                    if (seller != null) seller.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosEmpty()));
+                    if (seller != null) seller.sendMessage(BankAccounts.getInstance().config().messagesErrorsPosEmpty());
                     pos.get().delete();
                     return;
                 }
@@ -99,18 +98,18 @@ public class GUI implements Listener {
                 if (item.equals(confirm)) {
                     if (!POS.verifyChecksum(chestItems, checksums)) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosItemsChanged()));
+                        event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesErrorsPosItemsChanged());
                         final @Nullable Player seller = pos.get().seller.owner.getPlayer();
-                        if (seller != null) seller.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosItemsChanged()));
+                        if (seller != null) seller.sendMessage(BankAccounts.getInstance().config().messagesErrorsPosItemsChanged());
                         pos.get().delete();
                         return;
                     }
                     if (pos.get().seller.frozen) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), pos.get().seller));
+                        event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesErrorsFrozen(pos.get().seller));
                         final @Nullable Player seller = pos.get().seller.owner.getPlayer();
                         if (seller != null) {
-                            seller.sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), pos.get().seller));
+                            seller.sendMessage(BankAccounts.getInstance().config().messagesErrorsFrozen(pos.get().seller));
                             seller.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesPosRemoved()));
                         }
                         pos.get().delete();
@@ -118,19 +117,17 @@ public class GUI implements Listener {
                     }
                     if (buyer.get().frozen) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsFrozen(), buyer.get()));
+                        event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesErrorsFrozen(buyer.get()));
                         return;
                     }
                     if (!buyer.get().hasFunds(pos.get().price)) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(Account.placeholders(BankAccounts.getInstance().config().messagesErrorsInsufficientFunds(), buyer.get()));
+                        event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesErrorsInsufficientFunds(buyer.get()));
                         return;
                     }
                     if (event.getWhoClicked().getInventory().getSize() - event.getWhoClicked().getInventory().getStorageContents().length < items.length) {
                         inventory.close();
-                        event.getWhoClicked().sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsTargetInventoryFull(),
-                                Placeholder.unparsed("player", event.getWhoClicked().getName())
-                        ));
+                        event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesErrorsTargetInventoryFull(event.getWhoClicked()));
                         return;
                     }
                     inventory.close();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -134,7 +134,6 @@ public class GUI implements Listener {
                     chest.getInventory().clear();
                     event.getWhoClicked().getInventory().addItem(chestItems);
                     pos.get().delete();
-                    final @NotNull String itemsFormatted = chestItems.length == 1 ? "1 item" : chestItems.length + " items";
                     event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesPosPurchase(transaction, chestItems));
                     final @Nullable Player seller = pos.get().seller.owner.getPlayer();
                     if (seller != null)
@@ -160,10 +159,6 @@ public class GUI implements Listener {
 
     public final boolean isGuiItem(final @NotNull ItemStack item) {
         return item.hasItemMeta() && keys.entrySet().stream().anyMatch(entry -> Arrays.stream(entry.getValue()).anyMatch(key -> item.getItemMeta().getPersistentDataContainer().has(key)));
-    }
-
-    public final boolean isGuiItem(final @NotNull ItemStack item, final @NotNull NamespacedKey key) {
-        return item.hasItemMeta() && item.getItemMeta().getPersistentDataContainer().has(key);
     }
 
     public final boolean isGuiItem(final @NotNull ItemStack item, final @NotNull NamespacedKey[] key) {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -135,16 +135,10 @@ public class GUI implements Listener {
                     event.getWhoClicked().getInventory().addItem(chestItems);
                     pos.get().delete();
                     final @NotNull String itemsFormatted = chestItems.length == 1 ? "1 item" : chestItems.length + " items";
-                    event.getWhoClicked().sendMessage(Transaction.placeholders(transaction, BankAccounts.getInstance().config().messagesPosPurchase()
-                            .replace("<items>", String.valueOf(chestItems.length))
-                            .replace("<items-formatted>", itemsFormatted)
-                    ));
+                    event.getWhoClicked().sendMessage(BankAccounts.getInstance().config().messagesPosPurchase(transaction, chestItems));
                     final @Nullable Player seller = pos.get().seller.owner.getPlayer();
                     if (seller != null)
-                        seller.sendMessage(Transaction.placeholders(transaction, BankAccounts.getInstance().config().messagesPosPurchaseSeller()
-                                .replace("<items>", String.valueOf(chestItems.length))
-                                .replace("<items-formatted>", itemsFormatted)
-                        ));
+                        seller.sendMessage(BankAccounts.getInstance().config().messagesPosPurchaseSeller(transaction, items));
                 }
                 else if (item.equals(cancel)) {
                     inventory.close();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
@@ -27,11 +27,9 @@ public final class Join implements Listener {
                     }
                 }));
         if (player.hasPermission(Permissions.NOTIFY_UPDATE)) {
-            BankAccounts.getInstance().getServer().getScheduler().runTaskLater(BankAccounts.getInstance(), () -> {
-                BankAccounts.checkForUpdates().ifPresent(latestVersion -> {
-                    player.sendMessage(BankAccounts.getInstance().config().messagesUpdateAvailable(latestVersion));
-                });
-            }, 20L);
+            BankAccounts.getInstance().getServer().getScheduler().runTaskLater(BankAccounts.getInstance(), () -> BankAccounts.checkForUpdates().ifPresent(latestVersion -> {
+                player.sendMessage(BankAccounts.getInstance().config().messagesUpdateAvailable(latestVersion));
+            }), 20L);
         }
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
@@ -8,7 +8,6 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
-import pro.cloudnode.smp.bankaccounts.Command;
 import pro.cloudnode.smp.bankaccounts.Permissions;
 
 import java.math.BigDecimal;
@@ -30,8 +29,7 @@ public final class Join implements Listener {
         if (player.hasPermission(Permissions.NOTIFY_UPDATE)) {
             BankAccounts.getInstance().getServer().getScheduler().runTaskLater(BankAccounts.getInstance(), () -> {
                 BankAccounts.checkForUpdates().ifPresent(latestVersion -> {
-                    Command.sendMessage(player, BankAccounts.getInstance().config().messagesUpdateAvailable()
-                            .replace("<version>", latestVersion));
+                    player.sendMessage(BankAccounts.getInstance().config().messagesUpdateAvailable(latestVersion));
                 });
             }, 20L);
         }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/PlayerInteract.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts.events;
 
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
@@ -33,20 +32,20 @@ public final class PlayerInteract implements Listener {
                     return;
                 }
                 if (!player.hasPermission(Permissions.POS_USE)) {
-                    player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosNoPermission()));
+                    player.sendMessage(BankAccounts.getInstance().config().messagesErrorsPosNoPermission());
                     return;
                 }
                 final @NotNull ItemStack heldItem = player.getInventory().getItemInMainHand();
                 if (heldItem.getType() != BankAccounts.getInstance().config().instrumentsMaterial()) {
-                    player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsNoCard()));
+                    player.sendMessage(BankAccounts.getInstance().config().messagesErrorsNoCard());
                     return;
                 }
                 final @NotNull Optional<@NotNull Account> account = Account.get(heldItem);
                 if (account.isEmpty())
-                    player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsPosInvalidCard()));
+                    player.sendMessage(BankAccounts.getInstance().config().messagesErrorsPosInvalidCard());
                 else {
                     if (!player.hasPermission(Permissions.POS_USE_OTHER) && !account.get().owner.getUniqueId().equals(player.getUniqueId())) {
-                        player.sendMessage(MiniMessage.miniMessage().deserialize(BankAccounts.getInstance().config().messagesErrorsNotAccountOwner()));
+                        player.sendMessage(BankAccounts.getInstance().config().messagesErrorsNotAccountOwner());
                         return;
                     }
                     POS.openBuyGui(player, chest, pos.get(), account.get());


### PR DESCRIPTION
Moves all config placeholder replacements to their respective config methods, ensuring that the same placeholders are used and always set the same way.

Additionally makes all methods return the *best* return type, such as `Component` for messages, item names, lores, et al.