### PR TITLE
Use UUID to get POS world and `Server` instead of `Bukkit` static methods

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandExecutor;
@@ -90,7 +89,7 @@ public final class BankAccounts extends JavaPlugin {
         for (final @NotNull Listener event : events) getServer().getPluginManager().registerEvents(event, this);
 
         // Setup PlaceholderAPI Integration
-        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+        if(BankAccounts.getInstance().getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
             new PAPIIntegration().register();
         } else {
             getLogger().log(Level.INFO, "PlaceholderAPI not found. Skipping integration.");

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -29,6 +29,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.stream.IntStream;
 import java.util.zip.CRC32;
@@ -96,7 +97,7 @@ public final class POS {
         this.x = rs.getInt("x");
         this.y = rs.getInt("y");
         this.z = rs.getInt("z");
-        final @NotNull Optional<@NotNull World> world = Optional.ofNullable(BankAccounts.getInstance().getServer().getWorld(rs.getString("world")));
+        final @NotNull Optional<@NotNull World> world = Optional.ofNullable(BankAccounts.getInstance().getServer().getWorld(UUID.fromString(rs.getString("world"))));
         if (world.isEmpty()) throw new IllegalStateException("World not found: " + rs.getString("world"));
         this.world = world.get();
         this.price = rs.getBigDecimal("price");
@@ -123,7 +124,7 @@ public final class POS {
      * Create POS id
      */
     public @NotNull String id() {
-        return world.getName() + ":" + x + ":" + y + ":" + z;
+        return world.getUID() + ":" + x + ":" + y + ":" + z;
     }
 
     /**
@@ -135,7 +136,7 @@ public final class POS {
             stmt.setInt(1, x);
             stmt.setInt(2, y);
             stmt.setInt(3, z);
-            stmt.setString(4, world.getName());
+            stmt.setString(4, world.getUID().toString());
             stmt.setBigDecimal(5, price);
             if (description == null) stmt.setNull(6, Types.VARCHAR);
             else stmt.setString(6, description);
@@ -157,7 +158,7 @@ public final class POS {
             stmt.setInt(1, x);
             stmt.setInt(2, y);
             stmt.setInt(3, z);
-            stmt.setString(4, world.getName());
+            stmt.setString(4, world.getUID().toString());
             stmt.executeUpdate();
         } catch (final @NotNull SQLException e) {
             BankAccounts.getInstance().getLogger().log(Level.SEVERE, "Could not delete POS in " + world.getName() + " at X: " + x + " Y: " + y + " Z: " + z, e);
@@ -178,7 +179,7 @@ public final class POS {
             stmt.setInt(1, x);
             stmt.setInt(2, y);
             stmt.setInt(3, z);
-            stmt.setString(4, world.getName());
+            stmt.setString(4, world.getUID().toString());
             final @NotNull ResultSet rs = stmt.executeQuery();
             return rs.next() ? Optional.of(new POS(rs)) : Optional.empty();
         } catch (final @NotNull SQLException e) {
@@ -236,7 +237,7 @@ public final class POS {
     public static @NotNull Optional<@NotNull POS> get(final @NotNull String id) {
         final @NotNull String @NotNull [] split = id.split(":");
         if (split.length != 4) return Optional.empty();
-        final @NotNull Optional<@NotNull World> world = Optional.ofNullable(Bukkit.getWorld(split[0]));
+        final @NotNull Optional<@NotNull World> world = Optional.ofNullable(BankAccounts.getInstance().getServer().getWorld(UUID.fromString(split[0])));
         if (world.isEmpty()) return Optional.empty();
         try {
             final int x = Integer.parseInt(split[1]);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -264,7 +263,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
+        final @NotNull Inventory gui = BankAccounts.getInstance().getServer().createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);
@@ -309,7 +308,7 @@ public final class POS {
         final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
-        final @NotNull Inventory gui = Bukkit.createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
+        final @NotNull Inventory gui = BankAccounts.getInstance().getServer().createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/BlockBreak.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts.events;
 
-import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.event.EventHandler;
@@ -20,7 +19,7 @@ public final class BlockBreak implements Listener {
         if (block.getState() instanceof final @NotNull Chest chest) {
             final @NotNull Inventory inventory = chest.getInventory();
             if (!inventory.isEmpty()) {
-                Bukkit.getScheduler().runTaskAsynchronously(BankAccounts.getInstance(), () -> {
+                BankAccounts.getInstance().getServer().getScheduler().runTaskAsynchronously(BankAccounts.getInstance(), () -> {
                     final @NotNull Optional<POS> pos = POS.get(chest);
                     if (pos.isPresent()) {
                         pos.get().delete();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
@@ -1,6 +1,5 @@
 package pro.cloudnode.smp.bankaccounts.events;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -19,7 +18,7 @@ public final class Join implements Listener {
         final Player player = event.getPlayer();
         final @NotNull Optional<@NotNull Double> startingBalance = BankAccounts.getInstance().config()
                 .startingBalance();
-        startingBalance.ifPresent(aDouble -> Bukkit.getScheduler()
+        startingBalance.ifPresent(aDouble -> BankAccounts.getInstance().getServer().getScheduler()
                 .runTaskAsynchronously(BankAccounts.getInstance(), () -> {
                     final @NotNull Account[] accounts = Account.get(player, Account.Type.PERSONAL);
                     if (accounts.length == 0) {

--- a/src/main/resources/db-init/mysql.sql
+++ b/src/main/resources/db-init/mysql.sql
@@ -47,3 +47,10 @@ CREATE TABLE IF NOT EXISTS `bank_invoices`
     `created`     DATETIME                                                            NOT NULL DEFAULT UTC_TIMESTAMP(),
     `transaction` INT                                                                          DEFAULT NULL
 );
+
+DELETE
+from `pos`
+WHERE `world` NOT LIKE '%-%-%-%-%';
+
+ALTER TABLE `pos`
+    CHANGE COLUMN `world` `world` CHAR(36) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL;

--- a/src/main/resources/db-init/sql.sql
+++ b/src/main/resources/db-init/sql.sql
@@ -64,3 +64,31 @@ CREATE TABLE IF NOT EXISTS `bank_invoices`
     `created`     DATETIME             NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `transaction` INTEGER                       DEFAULT NULL
 );
+
+-- Modify `pos`.`world` to be `CHAR(36)` (UUID)
+DELETE
+from `pos`
+WHERE `world` NOT LIKE '%-%-%-%-%';
+
+CREATE TABLE `new_pos`
+(
+    `x`           INTEGER  NOT NULL,
+    `y`           INTEGER  NOT NULL,
+    `z`           INTEGER  NOT NULL,
+    `world`       CHAR(36) NOT NULL COLLATE NOCASE,
+    `price`       NUMERIC  NOT NULL,
+    `description` TEXT              DEFAULT NULL,
+    `seller`      TEXT     NOT NULL,
+    `created`     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`x`, `y`, `z`, `world`)
+);
+
+INSERT INTO `new_pos`
+SELECT *
+FROM `pos`;
+
+DROP TABLE `pos`;
+
+ALTER TABLE `new_pos`
+    RENAME TO `pos`;
+-- END OF `pos` MODIFICATION


### PR DESCRIPTION
1. Uses world UID instead of world name.
2. Replaces use of `Bukkit` static methods with `JavaPlugin#getServer()` (in the entire project)

> [!CAUTION]
> Any existing POS (with world name not in UUID format) will be deleted upon updating. See: https://github.com/cloudnode-pro/BankAccounts/blob/3a771ad42b070586bc9fc51b6de12a04e9fc2284/src/main/resources/db-init/mysql.sql#L51-L53