### PR TITLE
Fix baltop and confirm transfer buttons

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -1083,13 +1083,9 @@ public final class BankConfig {
                 Objects.requireNonNull(config.getString("messages.baltop.header"))
                         .replace("<category>", category)
                         .replace("<page>", String.valueOf(page))
-        ).replaceText(configurer -> {
-            configurer.matchLiteral("<cmd-prev>");
-            configurer.replacement(cmdPrev);
-        }).replaceText(configurer -> {
-            configurer.matchLiteral("<cmd-next>");
-            configurer.replacement(cmdNext);
-        });
+                        .replace("<cmd-prev>", cmdPrev)
+                        .replace("<cmd-next>", cmdNext)
+        );
     }
 
     // messages.baltop.entry

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -836,12 +836,10 @@ public final class BankConfig {
                         .replace("<to-balance-short>", BankAccounts.formatCurrencyShort(to.balance))
                         .replace("<amount>", amount.toPlainString())
                         .replace("<amount-formatted>", BankAccounts.formatCurrency(amount))
-                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(amount)),
+                        .replace("<amount-short>", BankAccounts.formatCurrencyShort(amount))
+                        .replace("<confirm-command>", "/bank transfer --confirm " + from.id + " " + to.id + " " + amount.toPlainString() + (description == null ? "" : " " + description)),
                 Placeholder.component("description", description == null ? MiniMessage.miniMessage().deserialize("<gray><i>no description</i>") : Component.text(description))
-        ).replaceText(configurer -> {
-            configurer.matchLiteral("<confirm-command>");
-            configurer.replacement(Component.text("/bank transfer --confirm " + from.id + " " + to.id + " " + amount.toPlainString() + (description == null ? "" : " " + description)));
-        });
+        );
     }
 
     // messages.transfer-sent


### PR DESCRIPTION
MiniMessage won't render the `<click…>…</click>` tags if there are `<>` characters *inside* the tag.

Due to that, replacements after rendering won't work.

Bug introduced in 26c9579f5aa64c20be08df37f7f4203f117a8c4d #90 [1.7.0](https://github.com/cloudnode-pro/BankAccounts/releases/tag/1.7.0)

One of the security concerns fixed in #90 was that description placeholders from inside the confirm command could affect the confirmation message or even inject a command. However, this is prevented by:
https://github.com/cloudnode-pro/BankAccounts/blob/5fb4c111382264b5d2ae83a0f7fe8acf5c2eac50/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java#L506-L507

And for the baltop command, it cannot be exploited as it's always `/<label> <page, verified int>`