### PR TITLE
Fix POS creating with async command

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -41,6 +41,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public final class BankAccounts extends JavaPlugin {
@@ -381,6 +384,32 @@ public final class BankAccounts extends JavaPlugin {
             plugin.getLogger().log(Level.WARNING, "Failed to check for updates", e);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Run a task on the main thread
+     * @param task The task to run
+     * @param timeout Task timeout in SECONDS. Set to 0 to disable timeout
+     */
+    public static <T> @NotNull Optional<T> runOnMain(@NotNull Callable<T> task, final long timeout) {
+        final @NotNull BankAccounts plugin = BankAccounts.getInstance();
+        final @NotNull Future<T> future = plugin.getServer().getScheduler().callSyncMethod(plugin, task);
+        try {
+            if (timeout == 0) return Optional.of(future.get());
+            return Optional.of(future.get(timeout, TimeUnit.SECONDS));
+        }
+        catch (final @NotNull Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to run task on main thread", e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Run a task on the main thread (without timeout)
+     * @param task The task to run
+     */
+    public static <T> @NotNull Optional<T> runOnMain(@NotNull Callable<T> task) {
+        return runOnMain(task, 0);
     }
 
     public static final class Key {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -694,6 +694,11 @@ public final class BankConfig {
         return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.player-never-joined")));
     }
 
+    // messages.errors.async-failed
+    public @NotNull Component messagesErrorsAsyncFailed() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.async-failed")));
+    }
+
     // messages.balance
     public @NotNull Component messagesBalance(final @NotNull Account account) {
         return MiniMessage.miniMessage().deserialize(

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -1,5 +1,6 @@
 package pro.cloudnode.smp.bankaccounts;
 
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -16,38 +17,38 @@ public abstract class Command implements CommandExecutor, TabCompleter {
     /**
      * Send message to sender.
      *
-     * @param sender  Command sender.
-     * @param message Message to send.
+     * @param audience Message recipient
+     * @param message  Message to send.
      * @return Always true.
      */
-    public static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull Component message) {
-        sender.sendMessage(message);
+    public static boolean sendMessage(final @NotNull Audience audience, final @NotNull Component message) {
+        audience.sendMessage(message);
         return true;
     }
 
     /**
      * Send message to sender.
      *
-     * @param sender       Command sender.
+     * @param audience     Message recipient
      * @param message      Message to send.
      * @param placeholders Placeholders to replace.
      * @return Always true.
      */
-    public static boolean sendMessage(final @NotNull CommandSender sender, final @NotNull String message, final @NotNull TagResolver @NotNull ... placeholders) {
-        sendMessage(sender, MiniMessage.miniMessage().deserialize(message, placeholders));
+    public static boolean sendMessage(final @NotNull Audience audience, final @NotNull String message, final @NotNull TagResolver @NotNull ... placeholders) {
+        sendMessage(audience, MiniMessage.miniMessage().deserialize(message, placeholders));
         return true;
     }
 
     /**
      * Send command usage to sender.
      *
-     * @param sender    Command sender.
+     * @param audience  Message recipient
      * @param label     Command label.
      * @param arguments Command arguments.
      * @return Always true.
      */
-    protected static boolean sendUsage(final @NotNull CommandSender sender, final @NotNull String label, final @NotNull String arguments) {
-        return sendMessage(sender, BankAccounts.getInstance().config().messagesCommandUsage(label, arguments));
+    protected static boolean sendUsage(final @NotNull Audience audience, final @NotNull String label, final @NotNull String arguments) {
+        return sendMessage(audience, BankAccounts.getInstance().config().messagesCommandUsage(label, arguments));
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -1,6 +1,7 @@
 package pro.cloudnode.smp.bankaccounts.commands;
 
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -65,7 +66,9 @@ public final class POSCommand extends Command {
         final @Nullable Block target = player.getTargetBlockExact(5);
         if (target == null) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsBlockTooFar());
 
-        if (!(target.getState() instanceof final @NotNull Chest chest))
+        final @NotNull Optional<@NotNull BlockState> block = BankAccounts.runOnMain(target::getState, 5);
+        if (block.isEmpty()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsAsyncFailed());
+        if (!(block.get() instanceof final @NotNull Chest chest))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosNotChest());
         if (chest.getInventory() instanceof DoubleChestInventory)
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosDoubleChest());

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/Join.java
@@ -26,7 +26,7 @@ public final class Join implements Listener {
                     }
                 }));
         if (player.hasPermission(Permissions.NOTIFY_UPDATE)) {
-            BankAccounts.getInstance().getServer().getScheduler().runTaskLater(BankAccounts.getInstance(), () -> BankAccounts.checkForUpdates().ifPresent(latestVersion -> {
+            BankAccounts.getInstance().getServer().getScheduler().runTaskLaterAsynchronously(BankAccounts.getInstance(), () -> BankAccounts.checkForUpdates().ifPresent(latestVersion -> {
                 player.sendMessage(BankAccounts.getInstance().config().messagesUpdateAvailable(latestVersion));
             }), 20L);
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -350,6 +350,8 @@ messages:
         invoice-cannot-send: "<red>(!) You cannot send this invoice to that player because they don't have permission to view it.</red>"
         # Player has never played on this server
         player-never-joined: "<red>(!) This player has never joined this server.</red>"
+        # Asynchronous code failed. Detailed info is outputted in the console
+        async-failed: "<red>(!) The request failed. See the console for details.</red>"
 
     # Account balance
     # Available placeholders:


### PR DESCRIPTION
POS command (all commands are executed async) cannot access chest from async context as Bukkit world data can only be accessed from the main thread.

This PR add a method to run code on the main thread and return the result back to the async thread.
https://github.com/cloudnode-pro/BankAccounts/blob/76cd84eba2ec33d71e7c8b7191785a8f6291778c/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java#L389-L405

> [!WARNING]
> The async thread is blocked until the main thread code is executed and data is returned.