### PR TITLE
Parse strings directly as BigDecimal

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -328,7 +328,7 @@ public final class BankAccounts extends JavaPlugin {
             if (accounts.length > 0) return;
             final @Nullable String name = getInstance().config().serverAccountName();
             final @NotNull Account.Type type = getInstance().config().serverAccountType();
-            final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance().map(BigDecimal::valueOf).orElse(null);
+            final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance();
             new Account(getConsoleOfflinePlayer(), type, name, balance, false).insert();
         }
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -146,10 +146,10 @@ public final class BankConfig {
     }
 
     // server-account.starting-balance
-    public @NotNull Optional<@NotNull Double> serverAccountStartingBalance() {
+    public @Nullable BigDecimal serverAccountStartingBalance() {
         if (Objects.requireNonNull(config.getString("server-account.starting-balance")).equalsIgnoreCase("infinity"))
-            return Optional.empty();
-        else return Optional.of(config.getDouble("server-account.starting-balance"));
+            return null;
+        else return new BigDecimal(Objects.requireNonNull(config.getString("server-account.starting-balance")));
     }
 
     // account-limits.
@@ -168,8 +168,8 @@ public final class BankConfig {
     }
 
     // transfer-confirmation.min-amount
-    public double transferConfirmationMinAmount() {
-        return config.getDouble("transfer-confirmation.min-amount");
+    public BigDecimal transferConfirmationMinAmount() {
+        return new BigDecimal(Objects.requireNonNull(config.getString("transfer-confirmation.min-amount")));
     }
 
     // transfer-confirmation.bypass-own-accounts

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -168,7 +168,7 @@ public final class BankConfig {
     }
 
     // transfer-confirmation.min-amount
-    public BigDecimal transferConfirmationMinAmount() {
+    public @NotNull BigDecimal transferConfirmationMinAmount() {
         return new BigDecimal(Objects.requireNonNull(config.getString("transfer-confirmation.min-amount")));
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -352,7 +352,7 @@ public class BankCommand extends Command {
         else {
             final @Nullable BigDecimal balance;
             try {
-                balance = args[1].equalsIgnoreCase("Infinity") ? null : BigDecimal.valueOf(Double.parseDouble(args[1]));
+                balance = args[1].equalsIgnoreCase("Infinity") ? null : new BigDecimal(args[1]);
             }
             catch (NumberFormatException e) {
                 return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(args[1]));
@@ -487,7 +487,7 @@ public class BankCommand extends Command {
 
         final @NotNull BigDecimal amount;
         try {
-            amount = BigDecimal.valueOf(Double.parseDouble(argsCopy[2])).setScale(2, RoundingMode.HALF_UP);
+            amount = new BigDecimal(argsCopy[2]).setScale(2, RoundingMode.HALF_UP);
         }
         catch (NumberFormatException e) {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(argsCopy[2]));
@@ -507,7 +507,7 @@ public class BankCommand extends Command {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters("<>"));
 
         if (!confirm && BankAccounts.getInstance().config().transferConfirmationEnabled()) {
-            final @NotNull BigDecimal minAmount = BigDecimal.valueOf(BankAccounts.getInstance().config().transferConfirmationMinAmount());
+            final @NotNull BigDecimal minAmount = BankAccounts.getInstance().config().transferConfirmationMinAmount();
             boolean bypassOwnAccounts = BankAccounts.getInstance().config().transferConfirmationBypassOwnAccounts();
             if (amount.compareTo(minAmount) >= 0 && (!bypassOwnAccounts || !from.get().owner.getUniqueId()
                     .equals(to.get().owner.getUniqueId()))) {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/InvoiceCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/InvoiceCommand.java
@@ -153,7 +153,7 @@ public final class InvoiceCommand extends Command {
 
         final @NotNull BigDecimal amount;
         try {
-            amount = BigDecimal.valueOf(Double.parseDouble(argsCopy[1])).setScale(2, RoundingMode.HALF_UP);
+            amount = new BigDecimal(argsCopy[1]).setScale(2, RoundingMode.HALF_UP);
         }
         catch (final @NotNull NumberFormatException e) {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(argsCopy[1]));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -53,7 +53,7 @@ public final class POSCommand extends Command {
 
         final @NotNull BigDecimal price;
         try {
-            price = BigDecimal.valueOf(Double.parseDouble(args[1])).setScale(2, RoundingMode.HALF_UP);
+            price = new BigDecimal(args[1]).setScale(2, RoundingMode.HALF_UP);
         }
         catch (final @NotNull NumberFormatException e) {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsInvalidNumber(args[1]));


### PR DESCRIPTION
This enhancement allows you to use large numbers in:
 - Command: [`/bank transfer`](https://github.com/cloudnode-pro/BankAccounts/wiki/Commands#bank-transfer-from-to-amount-description) (for the amount of money argument)
 - Command: [`/bank setbal`](https://github.com/cloudnode-pro/BankAccounts/wiki/Commands#bank-transfer-from-to-amount-description) (for the new balance argument)
 - Config: [`server-account.starting-balance`](https://github.com/cloudnode-pro/BankAccounts/blob/8e09ceabcf3c12a8ab829adb3ded848a1fd3a9b2/src/main/resources/config.yml#L70)
 - Config: [`transfer-confirmation.min-amount`](https://github.com/cloudnode-pro/BankAccounts/blob/8e09ceabcf3c12a8ab829adb3ded848a1fd3a9b2/src/main/resources/config.yml#L101)

Previously the maximum for these was `179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368`.