### PR TITLE
Skip CodeQL for file extensions like md, yml, xml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,17 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.yml'
+      - '**/*.xml'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.yml'
+      - '**/*.xml'
   schedule:
     - cron: '40 22 * * 2'
 
@@ -51,7 +59,7 @@ jobs:
 
     - uses: actions/setup-java@v3
       with:
-        distribution: 'corretto'
+        distribution: 'temurin'
         java-version: 17
 
     # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
CodeQL analyses for bad Java code. There's no point to run it if only .md, .yml or .xml files are changed.

This PR is an example: only a `.yml` file is changed, so CodeQL will not run.