### PR TITLE
Make Dependabot run it's checks at 06:00 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"


### PR DESCRIPTION
Apparently, by default, Dependabot will do its checks at a **random** time. This makes no sense to me. This PR makes Dependabot check for updates on Monday at 06:00 UTC.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime