### PR TITLE
Improved user text input sanitisation and extended supported chars in DB

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 
 public final class BankConfig {
     public @NotNull FileConfiguration config;
@@ -420,6 +421,11 @@ public final class BankConfig {
     // invoice.per-page
     public int invoicePerPage() {
         return config.getInt("invoice.per-page");
+    }
+
+    // disallowed-regex
+    public @NotNull Pattern disallowedRegex() {
+        return Pattern.compile(Objects.requireNonNull(config.getString("disallowed-regex")));
     }
 
     // messages.command-usage

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -24,6 +24,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TimeZone;
 
 public final class BankConfig {
@@ -624,10 +625,10 @@ public final class BankConfig {
     }
 
     // messages.errors.disallowed-characters
-    public @NotNull Component messagesErrorsDisallowedCharacters(final @NotNull String characters) {
+    public @NotNull Component messagesErrorsDisallowedCharacters(final @NotNull Set<@NotNull String> characters) {
         return MiniMessage.miniMessage().deserialize(
                 Objects.requireNonNull(config.getString("messages.errors.disallowed-characters")),
-                Placeholder.unparsed("characters", characters)
+                Placeholder.unparsed("characters", String.join("", characters))
         );
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -93,8 +93,10 @@ public abstract class Command implements CommandExecutor, TabCompleter {
                 .filter(codePoint -> codePoint > 0xFFFF)
                 .mapToObj(codePoint -> new String(Character.toChars(codePoint)))
                 .collect(Collectors.toSet());
-        final @NotNull Matcher matcher = Pattern.compile("[<>\\x00-\\x08\\x0B-\\x1F\\x7F-\\x9F\\u2400-\\u2421\\u200B-\\u200D\\uFEFF\\uD800-\\uDB7F\\uDFFF]").matcher(input);
+        final @NotNull Matcher matcher = BankAccounts.getInstance().config().disallowedRegex().matcher(input);
         while (matcher.find()) chars.add(matcher.group());
+        if (input.contains("<")) chars.add("<");
+        if (input.contains(">")) chars.add(">");
         return chars;
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class Command implements CommandExecutor, TabCompleter {
     /**
@@ -80,5 +82,19 @@ public abstract class Command implements CommandExecutor, TabCompleter {
     public final @Nullable List<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
         final @Nullable List<@NotNull String> suggestions = tab(sender, args);
         return Optional.ofNullable(suggestions).map(s -> s.stream().filter(suggestion -> suggestion.toLowerCase().startsWith(args[args.length - 1].toLowerCase())).toList()).orElse(null);
+    }
+
+    protected static @NotNull Set<@NotNull String> getDisallowedCharacters(final @Nullable String input) {
+        if (input == null) return Set.of();
+        final @NotNull Set<@NotNull String> chars = input
+                .codePoints()
+                .filter(codePoint -> codePoint > 0xFFFF)
+                .mapToObj(codePoint -> new String(Character.toChars(codePoint)))
+                .collect(Collectors.toSet());
+        if (input.contains("<"))
+            chars.add("<");
+        if (input.contains(">"))
+            chars.add(">");
+        return chars;
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Command.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public abstract class Command implements CommandExecutor, TabCompleter {
@@ -91,10 +93,8 @@ public abstract class Command implements CommandExecutor, TabCompleter {
                 .filter(codePoint -> codePoint > 0xFFFF)
                 .mapToObj(codePoint -> new String(Character.toChars(codePoint)))
                 .collect(Collectors.toSet());
-        if (input.contains("<"))
-            chars.add("<");
-        if (input.contains(">"))
-            chars.add(">");
+        final @NotNull Matcher matcher = Pattern.compile("[<>\\x00-\\x08\\x0B-\\x1F\\x7F-\\x9F\\u2400-\\u2421\\u200B-\\u200D\\uFEFF\\uD800-\\uDB7F\\uDFFF]").matcher(input);
+        while (matcher.find()) chars.add(matcher.group());
         return chars;
     }
 }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -501,7 +501,7 @@ public class BankCommand extends Command {
 
         @Nullable String description = args.length > 3 ? String
                 .join(" ", Arrays.copyOfRange(argsCopy, 3, argsCopy.length)).trim() : null;
-        if (description != null && description.length() > 64) description = description.substring(0, 64);
+        if (description != null && description.length() > 64) description = description.substring(0, 63) + "…";
 
         final @NotNull Set<@NotNull String> disallowedChars = getDisallowedCharacters(description);
         if (!disallowedChars.isEmpty())

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -382,8 +383,9 @@ public class BankCommand extends Command {
             name = name.length() > 32 ? name.substring(0, 32) : name;
             name = name.isEmpty() ? null : name;
 
-            if (name != null && (name.contains("<") || name.contains(">")))
-                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters("<>"));
+            final @NotNull Set<@NotNull String> disallowedChars = getDisallowedCharacters(name);
+            if (!disallowedChars.isEmpty())
+                return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(disallowedChars));
 
             account.get().name = name;
             account.get().update();
@@ -501,8 +503,9 @@ public class BankCommand extends Command {
                 .join(" ", Arrays.copyOfRange(argsCopy, 3, argsCopy.length)).trim() : null;
         if (description != null && description.length() > 64) description = description.substring(0, 64);
 
-        if (description != null && (description.contains("<") || description.contains(">")))
-            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters("<>"));
+        final @NotNull Set<@NotNull String> disallowedChars = getDisallowedCharacters(description);
+        if (!disallowedChars.isEmpty())
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(disallowedChars));
 
         if (!confirm && BankAccounts.getInstance().config().transferConfirmationEnabled()) {
             final @NotNull BigDecimal minAmount = BankAccounts.getInstance().config().transferConfirmationMinAmount();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/InvoiceCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/InvoiceCommand.java
@@ -177,7 +177,9 @@ public final class InvoiceCommand extends Command {
         if (account.get().frozen)
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsFrozen(account.get()));
 
-        final @Nullable String description = argsCopy.length < 3 ? null : String.join(" ", Arrays.copyOfRange(argsCopy, 2, argsCopy.length));
+        @Nullable String description = argsCopy.length < 3 ? null : String.join(" ", Arrays.copyOfRange(argsCopy, 2, argsCopy.length));
+        if (description != null && description.length() > 64) description = description.substring(0, 63) + "…";
+
         final @NotNull Set<@NotNull String> disallowedChars = getDisallowedCharacters(description);
         if (!disallowedChars.isEmpty())
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(disallowedChars));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/InvoiceCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/InvoiceCommand.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public final class InvoiceCommand extends Command {
@@ -177,6 +178,9 @@ public final class InvoiceCommand extends Command {
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsFrozen(account.get()));
 
         final @Nullable String description = argsCopy.length < 3 ? null : String.join(" ", Arrays.copyOfRange(argsCopy, 2, argsCopy.length));
+        final @NotNull Set<@NotNull String> disallowedChars = getDisallowedCharacters(description);
+        if (!disallowedChars.isEmpty())
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(disallowedChars));
 
         final @NotNull Invoice invoice = new Invoice(account.get(), amount, description, target);
         invoice.insert();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Create a POS at the location the player is looking at.
@@ -78,8 +79,9 @@ public final class POSCommand extends Command {
         @Nullable String description = args.length > 2 ? String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : null;
         if (description != null && description.length() > 64) description = description.substring(0, 64);
 
-        if (description != null && (description.contains("<") || description.contains(">")))
-            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters("<>"));
+        final @NotNull Set<@NotNull String> disallowedChars = getDisallowedCharacters(description);
+        if (!disallowedChars.isEmpty())
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsDisallowedCharacters(disallowedChars));
 
         final @NotNull POS pos = new POS(target.getLocation(), price, description, account.get(), new Date());
         pos.save();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/POSCommand.java
@@ -77,7 +77,7 @@ public final class POSCommand extends Command {
         if (POS.get(chest).isPresent()) return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsPosAlreadyExists());
 
         @Nullable String description = args.length > 2 ? String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : null;
-        if (description != null && description.length() > 64) description = description.substring(0, 64);
+        if (description != null && description.length() > 64) description = description.substring(0, 63) + "…";
 
         final @NotNull Set<@NotNull String> disallowedChars = getDisallowedCharacters(description);
         if (!disallowedChars.isEmpty())

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -257,6 +257,12 @@ invoice:
     # Number of invoices to return per page
     per-page: 10
 
+# Advanced: do not edit unless you have good understanding of RegEx
+# Regular expression for disallowed characters user-provided text inputs
+# e.g. account name, transaction description, POS description, invoice description
+# Note: additionally <> and characters with code point above 0xFFFF are always disallowed.
+disallowed-regex: [\x00-\x08\x0B-\x1F\x7F-\x9F\u2400-\u2421\u200B-\u200D\uFEFF\uD800-\uDB7F\uDFFF]
+
 # Messages
 messages:
     # Command usage message

--- a/src/main/resources/db-init/mysql.sql
+++ b/src/main/resources/db-init/mysql.sql
@@ -54,3 +54,15 @@ WHERE `world` NOT LIKE '%-%-%-%-%';
 
 ALTER TABLE `pos`
     CHANGE COLUMN `world` `world` CHAR(36) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL;
+
+ALTER TABLE `bank_accounts`
+    CHANGE COLUMN `name` `name` VARCHAR(24) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL;
+
+ALTER TABLE `bank_transactions`
+    CHANGE COLUMN `description` `description` VARCHAR(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL;
+
+ALTER TABLE `pos`
+    CHANGE COLUMN `description` `description` VARCHAR(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL;
+
+ALTER TABLE `bank_invoices`
+    CHANGE COLUMN `description` `description` VARCHAR(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL;


### PR DESCRIPTION
Alters table columns to change the collation from latin1_general to utf8mb3_general to enable the use of foreign languages.

Validates that strings a user provides for such columns do not exceed codepoint 0xFFFF which is the maximum supported by utf8mb3. Additional characters can be excluded with configurable RegEx:

https://github.com/cloudnode-pro/BankAccounts/blob/308dfcc4eeee071efb6c56bbd3e6e3374ff9789e/src/main/resources/config.yml#L260-L264

Descriptions that exceed the column string length limit will be cut and `…` (a single character) will be appended. This should prevent DB errors while also indicating to users that the description was cut short.