### PR TITLE
Creating account on join is optional if Vault not enabled

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -132,7 +132,7 @@ public final class BankConfig {
 
     // starting-balance
     public @NotNull Optional<@NotNull BigDecimal> startingBalance() {
-        if (Objects.requireNonNull(config.getString("starting-balance")).equalsIgnoreCase("null"))
+        if (Objects.requireNonNull(config.getString("starting-balance")).equalsIgnoreCase("false"))
             return Optional.empty();
         else return Optional.of(new BigDecimal(Objects.requireNonNull(config.getString("starting-balance"))));
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -131,10 +131,10 @@ public final class BankConfig {
     }
 
     // starting-balance
-    public @NotNull BigDecimal startingBalance() {
+    public @NotNull Optional<@NotNull BigDecimal> startingBalance() {
         if (Objects.requireNonNull(config.getString("starting-balance")).equalsIgnoreCase("null"))
-            return BigDecimal.ZERO;
-        else return new BigDecimal(Objects.requireNonNull(config.getString("starting-balance")));
+            return Optional.empty();
+        else return Optional.of(new BigDecimal(Objects.requireNonNull(config.getString("starting-balance"))));
     }
 
     // server-account.name

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,6 +52,8 @@ currency:
     format: "#,##0.00"
 
 # Starting balance
+# Min value is 0. Set to `null` to disable creating an account on join.
+# If the Vault integration is enabled and this is set to `null`, an account with 0 balance will be created regardless.
 starting-balance: 0
 
 # Server account

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,9 +52,9 @@ currency:
     format: "#,##0.00"
 
 # Starting balance
-# Min value is 0. Set to `null` to disable creating an account on join.
+# Min value is 0. Set to false to disable creating an account on join.
 # If the Vault integration is enabled and this is set to `null`, an account with 0 balance will be created regardless.
-starting-balance: 0
+starting-balance: false
 
 # Server account
 server-account:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,9 +52,9 @@ currency:
     format: "#,##0.00"
 
 # Starting balance
-# Min value is 0. Set to false to disable creating an account on join.
-# If the Vault integration is enabled and this is set to `null`, an account with 0 balance will be created regardless.
-starting-balance: false
+# Min value is 0. Set to "false" to disable creating an account on join.
+# If the Vault integration is enabled and this is set to "false", an account with 0 balance will be created regardless.
+starting-balance: 0
 
 # Server account
 server-account:


### PR DESCRIPTION
If the Vault integration is not enabled, it's possible to set the starting balance to `null` to prevent creating an account when the player joins.