### PR TITLE
Add server Vault account to use for proxying Vault transactions

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -341,6 +341,7 @@ public class Account {
      * Get the server account
      */
     public static @NotNull Optional<@NotNull Account> getServerAccount() {
+        if (!BankAccounts.getInstance().config().serverAccountEnabled()) return Optional.empty();
         final @NotNull Account @NotNull [] accounts = get(BankAccounts.getConsoleOfflinePlayer());
         if (accounts.length == 0) return Optional.empty();
         return Optional.of(accounts[0]);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -348,6 +348,14 @@ public class Account {
     }
 
     /**
+     * Get the server Vault account
+     */
+    public static @NotNull Optional<@NotNull Account> getServerVaultAccount() {
+        if (!BankAccounts.getInstance().config().serverAccountEnabled()) return Optional.empty();
+        return getVaultAccount(BankAccounts.getConsoleOfflinePlayer());
+    }
+
+    /**
      * Insert into database
      */
     public void insert() {

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -342,9 +343,8 @@ public class Account {
      */
     public static @NotNull Optional<@NotNull Account> getServerAccount() {
         if (!BankAccounts.getInstance().config().serverAccountEnabled()) return Optional.empty();
-        final @NotNull Account @NotNull [] accounts = get(BankAccounts.getConsoleOfflinePlayer());
-        if (accounts.length == 0) return Optional.empty();
-        return Optional.of(accounts[0]);
+        final @NotNull Optional<@NotNull Account> account = Arrays.stream(get(BankAccounts.getConsoleOfflinePlayer())).filter(a -> a.type != Type.VAULT).findFirst();
+        return account;
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/Account.java
@@ -351,7 +351,7 @@ public class Account {
      * Get the server Vault account
      */
     public static @NotNull Optional<@NotNull Account> getServerVaultAccount() {
-        if (!BankAccounts.getInstance().config().serverAccountEnabled()) return Optional.empty();
+        if (!BankAccounts.getInstance().config().integrationsVaultEnabled()) return Optional.empty();
         return getVaultAccount(BankAccounts.getConsoleOfflinePlayer());
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -334,7 +334,7 @@ public final class BankAccounts extends JavaPlugin {
             if (accounts.length > 0) return;
             final @Nullable String name = getInstance().config().serverAccountName();
             final @NotNull Account.Type type = getInstance().config().serverAccountType();
-            final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance().map(BigDecimal::valueOf).orElse(null);
+            final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance();
             new Account(getConsoleOfflinePlayer(), type, name, balance, false).insert();
         }
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -329,12 +329,14 @@ public final class BankAccounts extends JavaPlugin {
      * Create server account, if enabled in config
      */
     private static void createServerAccount() {
-        final @NotNull Account @NotNull [] accounts = Account.get(getConsoleOfflinePlayer());
-        if (accounts.length > 0) return;
-        final @Nullable String name = getInstance().config().serverAccountName();
-        final @NotNull Account.Type type = getInstance().config().serverAccountType();
-        final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance();
-        new Account(getConsoleOfflinePlayer(), type, name, balance, false).insert();
+        if (getInstance().config().serverAccountEnabled()) {
+            final @NotNull Account @NotNull [] accounts = Account.get(getConsoleOfflinePlayer());
+            if (accounts.length > 0) return;
+            final @Nullable String name = getInstance().config().serverAccountName();
+            final @NotNull Account.Type type = getInstance().config().serverAccountType();
+            final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance().map(BigDecimal::valueOf).orElse(null);
+            new Account(getConsoleOfflinePlayer(), type, name, balance, false).insert();
+        }
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -155,6 +155,7 @@ public final class BankAccounts extends JavaPlugin {
         getInstance().setupDbSource();
         getInstance().initDbWrapper();
         createServerAccount();
+        createServerVaultAccount();
         getInstance().getServer().getScheduler().runTaskAsynchronously(getInstance(), () -> checkForUpdates().ifPresent(latestVersion -> {
             getInstance().getLogger().warning("An update is available: " + latestVersion);
             getInstance().getLogger().warning("Please update to the latest version to benefit from bug fixes, security patches, new features and support.");
@@ -337,6 +338,19 @@ public final class BankAccounts extends JavaPlugin {
             final @NotNull Account.Type type = getInstance().config().serverAccountType();
             final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance();
             new Account(getConsoleOfflinePlayer(), type, name, balance, false).insert();
+        }
+    }
+
+    /**
+     * Create server Vault account, if Vault enabled
+     */
+    private static void createServerVaultAccount() {
+        if (getInstance().config().integrationsVaultEnabled()) {
+            final @NotNull Optional<@NotNull Account> serverAccount = Account.getServerVaultAccount();
+            if (serverAccount.isPresent()) return;
+
+            final @Nullable String name = getInstance().config().integrationsVaultServerAccount();
+            new Account(getConsoleOfflinePlayer(), Account.Type.VAULT, name, BigDecimal.ZERO, true);
         }
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -330,8 +330,9 @@ public final class BankAccounts extends JavaPlugin {
      */
     private static void createServerAccount() {
         if (getInstance().config().serverAccountEnabled()) {
-            final @NotNull Account @NotNull [] accounts = Account.get(getConsoleOfflinePlayer());
-            if (accounts.length > 0) return;
+            final @NotNull Optional<@NotNull Account> account = Account.getServerAccount();
+            if (account.isPresent()) return;
+
             final @Nullable String name = getInstance().config().serverAccountName();
             final @NotNull Account.Type type = getInstance().config().serverAccountType();
             final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance();

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -120,6 +120,11 @@ public final class BankConfig {
         return Objects.requireNonNull(config.getString("integrations.vault.description"));
     }
 
+    // integrations.vault.server-account
+    public @NotNull String integrationsVaultServerAccount() {
+        return Objects.requireNonNull(config.getString("integrations.vault.server-account"));
+    }
+
     // currency.symbol
     public @NotNull String currencySymbol() {
         return Objects.requireNonNull(config.getString("currency.symbol"));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -137,6 +137,11 @@ public final class BankConfig {
         else return Optional.of(new BigDecimal(Objects.requireNonNull(config.getString("starting-balance"))));
     }
 
+    // server-account.enabled
+    public boolean serverAccountEnabled() {
+        return config.getBoolean("server-account.enabled");
+    }
+
     // server-account.name
     public @NotNull String serverAccountName() {
         return Objects.requireNonNull(config.getString("server-account.name"));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/VaultIntegration.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/VaultIntegration.java
@@ -235,7 +235,7 @@ public final class VaultIntegration {
             if (account.isEmpty()) return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.FAILURE, "Account not found");
             if (!account.get().hasFunds(BigDecimal.valueOf(amount)))
                 return new EconomyResponse(amount, Optional.ofNullable(account.get().balance).map(BigDecimal::doubleValue).orElse(Double.MAX_VALUE), EconomyResponse.ResponseType.FAILURE, "Insufficient funds");
-            final @NotNull Account serverAccount = Account.getServerAccount().orElse(new Account.ClosedAccount());
+            final @NotNull Account serverAccount = Account.getServerVaultAccount().orElse(new Account.ClosedAccount());
             // transfer funds to the server account since Vault just wants them "gone"
             account.get().transfer(serverAccount, BigDecimal.valueOf(amount), BankAccounts.getInstance().config().integrationsVaultDescription(), null);
             // remove funds from the server account without a transaction
@@ -287,7 +287,7 @@ public final class VaultIntegration {
         public @NotNull EconomyResponse depositPlayer(final @NotNull OfflinePlayer player, final double amount) {
             final @NotNull Optional<@NotNull Account> account = Account.getVaultAccount(player);
             if (account.isEmpty()) return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.FAILURE, "Account not found");
-            final @NotNull Account serverAccount = Account.getServerAccount().orElse(new Account.ClosedAccount());
+            final @NotNull Account serverAccount = Account.getServerVaultAccount().orElse(new Account.ClosedAccount());
             // add money to the server account and then transfer it to the player
             serverAccount.updateBalance(BigDecimal.valueOf(amount));
             serverAccount.transfer(account.get(), BigDecimal.valueOf(amount), BankAccounts.getInstance().config().integrationsVaultDescription(), null);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,6 +43,10 @@ integrations:
         # Transaction description for all vault operations
         description: Vault Transaction
 
+        # Name of the server Vault account
+        # All Vault transactions will appear as to/from this account.
+        server-account: Server Vault
+
 currency:
     # Currency symbol
     symbol: $

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,6 +58,9 @@ starting-balance: 0
 
 # Server account
 server-account:
+    # If enabled, when the plugin is loaded an account will be created as player with UUID 00000000-0000-0000-0000-000000000000
+    # This is required for features like interest to work.
+    enabled: true
     # Display name for the server account
     name: Central Bank
     # Account type


### PR DESCRIPTION
Instead of using the main server account, a new (type `VAULT`) account is added, which is used for Vault transactions. Vault transactions will now show as to/from this account.

This account _should_ (in theory) always have a balance of 0. The account is marked "frozen" to prevent players from sending funds to it. This account is for internal use only, please do not use it for anything else (consider creating regular server accounts instead).