### PR TITLE
Server Vault account: insert in DB and unfreeze

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -350,7 +350,7 @@ public final class BankAccounts extends JavaPlugin {
             if (serverAccount.isPresent()) return;
 
             final @NotNull String name = getInstance().config().integrationsVaultServerAccount();
-            new Account(getConsoleOfflinePlayer(), Account.Type.VAULT, name, BigDecimal.ZERO, true);
+            new Account(getConsoleOfflinePlayer(), Account.Type.VAULT, name, BigDecimal.ZERO, true).insert();
         }
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -350,7 +350,7 @@ public final class BankAccounts extends JavaPlugin {
             if (serverAccount.isPresent()) return;
 
             final @NotNull String name = getInstance().config().integrationsVaultServerAccount();
-            new Account(getConsoleOfflinePlayer(), Account.Type.VAULT, name, BigDecimal.ZERO, true).insert();
+            new Account(getConsoleOfflinePlayer(), Account.Type.VAULT, name, BigDecimal.ZERO, false).insert();
         }
     }
 

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankAccounts.java
@@ -334,7 +334,7 @@ public final class BankAccounts extends JavaPlugin {
             final @NotNull Optional<@NotNull Account> account = Account.getServerAccount();
             if (account.isPresent()) return;
 
-            final @Nullable String name = getInstance().config().serverAccountName();
+            final @NotNull String name = getInstance().config().serverAccountName();
             final @NotNull Account.Type type = getInstance().config().serverAccountType();
             final @Nullable BigDecimal balance = getInstance().config().serverAccountStartingBalance();
             new Account(getConsoleOfflinePlayer(), type, name, balance, false).insert();
@@ -349,7 +349,7 @@ public final class BankAccounts extends JavaPlugin {
             final @NotNull Optional<@NotNull Account> serverAccount = Account.getServerVaultAccount();
             if (serverAccount.isPresent()) return;
 
-            final @Nullable String name = getInstance().config().integrationsVaultServerAccount();
+            final @NotNull String name = getInstance().config().integrationsVaultServerAccount();
             new Account(getConsoleOfflinePlayer(), Account.Type.VAULT, name, BigDecimal.ZERO, true);
         }
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/BankConfig.java
@@ -716,6 +716,11 @@ public final class BankConfig {
         return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.delete-vault-account")));
     }
 
+    //messages.errors.transfer-to-server-vault
+    public @NotNull Component messagesErrorsTransferToServerVault() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("messages.errors.transfer-to-server-vault")));
+    }
+
     // messages.balance
     public @NotNull Component messagesBalance(final @NotNull Account account) {
         return MiniMessage.miniMessage().deserialize(

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/commands/BankCommand.java
@@ -530,6 +530,9 @@ public class BankCommand extends Command {
         if (!sender.hasPermission(Permissions.TRANSFER_SELF) && to.get().owner.getUniqueId()
                 .equals(BankAccounts.getOfflinePlayer(sender).getUniqueId()))
             return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsTransferOtherOnly());
+        // to is server Vault account
+        if (to.get().owner.getUniqueId().equals(BankAccounts.getConsoleOfflinePlayer().getUniqueId()) && to.get().type == Account.Type.VAULT)
+            return sendMessage(sender, BankAccounts.getInstance().config().messagesErrorsTransferToServerVault());
 
         final @NotNull BigDecimal amount;
         try {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -367,6 +367,8 @@ messages:
         async-failed: "<red>(!) The request failed. See the console for details.</red>"
         # Trying to delete vault integration account
         delete-vault-account: "<red>(!) You cannot delete this account.</red>"
+        # Trying to transfer funds to the server Vault account
+        transfer-to-server-vault: "<red>(!) You cannot transfer funds to this account. This account is for internal use only.</red>"
 
     # Account balance
     # Available placeholders:


### PR DESCRIPTION
After instantiating the server Vault account, I forgot to insert it into the DB. Also, the server Vault account is no longer frozen (which completely prevents it from being used even by Vault) and instead sending funds to it is disabled in the `/bank transfer` command.

These are bugs in #140