### PR TITLE
Entirely prevent modifying POS items while a player is viewing the POS contents

### DIFF
--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -271,7 +271,7 @@ public final class POS {
      * @param pos    The POS
      */
     public static void openOwnerGui(final @NotNull Player player, final @NotNull Chest chest, final @NotNull POS pos) {
-        final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
+        final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).map(ItemStack::clone).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
         final @NotNull Inventory gui = BankAccounts.getInstance().getServer().createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
@@ -317,7 +317,7 @@ public final class POS {
      * @param pos    The POS
      */
     public static void openBuyGui(final @NotNull Player player, final @NotNull Chest chest, final @NotNull POS pos, final @NotNull Account account) {
-        final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new);
+        final @NotNull ItemStack @NotNull [] items = Arrays.stream(chest.getInventory().getStorageContents()).filter(Objects::nonNull).map(ItemStack::clone).toArray(ItemStack[]::new);
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
         final @NotNull Inventory gui = BankAccounts.getInstance().getServer().createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/POS.java
@@ -26,6 +26,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -65,6 +66,8 @@ public final class POS {
      * Date the POS was created
      */
     public final @NotNull Date created;
+
+    public final static @NotNull HashMap<@NotNull Inventory, @NotNull POS> activePosChestGuis = new HashMap<>();
 
     /**
      * Create new POS instance
@@ -116,6 +119,15 @@ public final class POS {
      */
     public @NotNull Block getBlock() {
         return getLocation().getBlock();
+    }
+
+    /**
+     * Get POS chest
+     */
+    public @Nullable Chest getChest() {
+        if (getBlock().getState() instanceof final @NotNull Chest chest) return chest;
+        delete();
+        return null;
     }
 
     /**
@@ -263,6 +275,7 @@ public final class POS {
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
         final @NotNull Inventory gui = BankAccounts.getInstance().getServer().createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
+        POS.activePosChestGuis.put(gui, pos);
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);
@@ -308,6 +321,7 @@ public final class POS {
         final int extraRows = 1;
         final int size = extraRows * 9 + items.length + 9 - items.length % 9;
         final @NotNull Inventory gui = BankAccounts.getInstance().getServer().createInventory(null, size, BankAccounts.getInstance().config().posTitle(pos));
+        POS.activePosChestGuis.put(gui, pos);
         gui.addItem(items);
 
         final @NotNull ItemStack overview = new ItemStack(BankAccounts.getInstance().config().posInfoMaterial(), 1);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -161,11 +161,13 @@ public class GUI implements Listener {
      */
     @EventHandler(priority = EventPriority.HIGHEST)
     public void posItemsChangeWhileOpened(final @NotNull InventoryMoveItemEvent event) {
-        final @NotNull Inventory inventory = event.getSource();
+        final @NotNull Inventory source = event.getSource();
+        final @NotNull Inventory destination = event.getDestination();
         for (final @NotNull POS pos : POS.activePosChestGuis.values()) {
             final @Nullable Chest chest = pos.getChest();
             if (chest == null) continue;
-            if (inventory.equals(chest.getInventory())) {
+            final @NotNull Inventory chestInventory = chest.getInventory();
+            if (source.equals(chestInventory) || destination.equals(chestInventory)) {
                 event.setCancelled(true);
                 return;
             }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -180,7 +180,9 @@ public class GUI implements Listener {
     @EventHandler
     public void posGuiClosed(final @NotNull InventoryCloseEvent event) {
         if (!POS.activePosChestGuis.containsKey(event.getInventory())) return;
-        POS.activePosChestGuis.remove(event.getInventory());
+        BankAccounts.getInstance().getServer().getScheduler().runTaskLater(BankAccounts.getInstance(), () -> {
+            POS.activePosChestGuis.remove(event.getInventory());
+        }, 40L);
     }
 
     public final static @NotNull HashMap<@NotNull String, @NotNull NamespacedKey[]> keys = new HashMap<>() {{

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -5,10 +5,13 @@ import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -150,6 +153,32 @@ public class GUI implements Listener {
     public void onInventoryClick(final @NotNull InventoryDragEvent event) {
         if (hasGuiItem(event.getInventory()))
             event.setCancelled(true);
+    }
+
+    /**
+     * Detect changes in items of POS chest while a POS GUI is opened and prevent the item change.
+     * POS items can still be modified if no POS GUI is opened for that POS.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void posItemsChangeWhileOpened(final @NotNull InventoryMoveItemEvent event) {
+        final @NotNull Inventory inventory = event.getSource();
+        for (final @NotNull POS pos : POS.activePosChestGuis.values()) {
+            final @Nullable Chest chest = pos.getChest();
+            if (chest == null) continue;
+            if (inventory.equals(chest.getInventory())) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    /**
+     * POS GUI closed
+     */
+    @EventHandler
+    public void posGuiClosed(final @NotNull InventoryCloseEvent event) {
+        if (!POS.activePosChestGuis.containsKey(event.getInventory())) return;
+        POS.activePosChestGuis.remove(event.getInventory());
     }
 
     public final static @NotNull HashMap<@NotNull String, @NotNull NamespacedKey[]> keys = new HashMap<>() {{

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -180,9 +180,7 @@ public class GUI implements Listener {
     @EventHandler
     public void posGuiClosed(final @NotNull InventoryCloseEvent event) {
         if (!POS.activePosChestGuis.containsKey(event.getInventory())) return;
-        BankAccounts.getInstance().getServer().getScheduler().runTaskLater(BankAccounts.getInstance(), () -> {
-            POS.activePosChestGuis.remove(event.getInventory());
-        }, 40L);
+        POS.activePosChestGuis.remove(event.getInventory());
     }
 
     public final static @NotNull HashMap<@NotNull String, @NotNull NamespacedKey[]> keys = new HashMap<>() {{

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/events/GUI.java
@@ -159,7 +159,7 @@ public class GUI implements Listener {
      * Detect changes in items of POS chest while a POS GUI is opened and prevent the item change.
      * POS items can still be modified if no POS GUI is opened for that POS.
      */
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void posItemsChangeWhileOpened(final @NotNull InventoryMoveItemEvent event) {
         final @NotNull Inventory source = event.getSource();
         final @NotNull Inventory destination = event.getDestination();


### PR DESCRIPTION
This PR fixes a bug that causes items from the POS chest to be permanently deleted.

This PR also adds functionality that prevents modifying the POS items (using a hopper or hopper minecart or similar) while a POS preview GUI is open.

<details>
<summary>Existing behaviour which has not been altered in this PR</summary>

As a reminder:
- POS chests are not protected in any way. Anyone can break them and so on. To protect them, use another plugin for land protection.
- If a player has opened the chest before it becomes a POS chest, they can modify the POS items
- When the buyer clicks "Buy", the POS will verify that the items currently in the chest match the preview snapshot the buyer is seeing. If they do not match, the POS will be cancelled and a message will be shown. This is to prevent tricking buyers by modifying the chest items after the buyer has opened the buy GUI.
</detail>