### PR TITLE
Add placeholders for total balance and list of accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ enabling compatibility with third-party plugins that support Vault.
 
 You can create a [Point of Sale](https://github.com/cloudnode-pro/BankAccounts/wiki/POS), which is a type of single-use chest shop. Players can pay using a bank card (`/bank card`).
 
+### PlaceholderAPI Support
+
+BankAccounts provides several *PlaceholderAPI* placeholders that you can use. See
+the [Placeholders Wiki](https://github.com/cloudnode-pro/BankAccounts/wiki/Placeholders) for an exhaustive list.
+
 ### Extensive Configuration
 
 All functionality is fully configurable. See [default config](https://github.com/cloudnode-pro/BankAccounts/blob/master/src/main/resources/config.yml).

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
@@ -51,6 +51,17 @@ public final class PAPIIntegration extends PlaceholderExpansion {
                             );
                         yield null;
                     }
+                    case "short" -> {
+                        if (args.length == 3)
+                            yield Account.get(Account.Tag.from(args[2])).map(value -> BankAccounts.formatCurrencyShort(value.balance)).orElse(null);
+                        if (args.length == 2)
+                            yield BankAccounts.formatCurrencyShort(
+                                    Arrays.stream(Account.get(player))
+                                            .map(account -> account.balance)
+                                            .reduce(BigDecimal.ZERO, BigDecimal::add)
+                            );
+                        yield null;
+                    }
                     default -> Account.get(Account.Tag.from(args[1])).map(value -> String.valueOf(value.balance)).orElse(null);
                 };
             }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
@@ -26,16 +26,6 @@ public final class PAPIIntegration extends PlaceholderExpansion {
         return BankAccounts.getInstance().getPluginMeta().getVersion();
     }
 
-    /**
-     *  Adds the following placeholders:
-     *  <ul>
-     *      <li>%bankaccounts_balance_&lt;accountID&gt;% - returns balance of account with specified ID</li>
-     *      <li>%bankaccounts_balance_formatted_&lt;accountID&gt;% - returns formatted balance of account with specified ID</li>
-     *      <li>%bankaccounts_owner_&lt;accountID&gt;% - returns name of the owner of account with specified ID</li>
-     *      <li>%bankaccounts_type_&lt;accountID&gt;% - returns type of account with specified ID</li>
-     *      <li>%bankaccounts_name_&lt;accountID&gt;% - returns name of account with specified ID</li>
-     *  </ul>
-    */
     @Override
     public String onRequest(final @NotNull OfflinePlayer player, final @NotNull String params) {
         final @NotNull String[] args = params.split("_");

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
@@ -67,7 +67,7 @@ public final class PAPIIntegration extends PlaceholderExpansion {
             }
             case "owner" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.owner.getName()).orElse(null);
             case "type" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.type.getName()).orElse(null);
-            case "name" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.name).orElse(null);
+            case "name" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(Account::name).orElse(null);
             case "account" -> {
                 if (args.length == 2) {
                     final @NotNull Account @NotNull [] accounts = Account.get(player);

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
@@ -63,9 +63,9 @@ public final class PAPIIntegration extends PlaceholderExpansion {
                     default -> Account.get(Account.Tag.from(args[1])).map(value -> String.valueOf(value.balance)).orElse(null);
                 };
             }
-            case "owner" -> args.length < 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.owner.getName()).orElse(null);
-            case "type" -> args.length < 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.type.getName()).orElse(null);
-            case "name" -> args.length < 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.name).orElse(null);
+            case "owner" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.owner.getName()).orElse(null);
+            case "type" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.type.getName()).orElse(null);
+            case "name" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.name).orElse(null);
             default -> null;
         };
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
@@ -8,6 +8,7 @@ import pro.cloudnode.smp.bankaccounts.BankAccounts;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public final class PAPIIntegration extends PlaceholderExpansion {
     @Override
@@ -66,6 +67,18 @@ public final class PAPIIntegration extends PlaceholderExpansion {
             case "owner" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.owner.getName()).orElse(null);
             case "type" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.type.getName()).orElse(null);
             case "name" -> args.length != 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.name).orElse(null);
+            case "account" -> {
+                if (args.length == 2) {
+                    final @NotNull Account @NotNull [] accounts = Account.get(player);
+                    yield switch (args[1]) {
+                        case "list" -> Arrays.stream(accounts).map(account -> account.id).collect(Collectors.joining(", "));
+                        case "names" -> Arrays.stream(accounts).map(Account::name).collect(Collectors.joining(", "));
+                        case "count" -> String.valueOf(accounts.length);
+                        default -> null;
+                    };
+                }
+                yield null;
+            }
             default -> null;
         };
     }

--- a/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
+++ b/src/main/java/pro/cloudnode/smp/bankaccounts/integrations/PAPIIntegration.java
@@ -6,6 +6,9 @@ import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.bankaccounts.Account;
 import pro.cloudnode.smp.bankaccounts.BankAccounts;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
+
 public final class PAPIIntegration extends PlaceholderExpansion {
     @Override
     public @NotNull String getIdentifier() {
@@ -38,10 +41,28 @@ public final class PAPIIntegration extends PlaceholderExpansion {
 
         if (args.length < 1) return null;
         return switch (args[0]) {
-            case "balance" -> args.length < 2 ? null : switch (args[1]) {
-                case "formatted" -> args.length != 3 ? null : Account.get(Account.Tag.from(args[2])).map(value -> BankAccounts.formatCurrency(value.balance)).orElse(null);
-                default -> Account.get(Account.Tag.from(args[1])).map(value -> String.valueOf(value.balance)).orElse(null);
-            };
+            case "balance" -> {
+                if (args.length == 1)
+                    yield String.valueOf(
+                            Arrays.stream(Account.get(player))
+                                    .map(account -> account.balance)
+                                    .reduce(BigDecimal.ZERO, BigDecimal::add)
+                    );
+                yield switch (args[1]) {
+                    case "formatted" -> {
+                        if (args.length == 3)
+                            yield Account.get(Account.Tag.from(args[2])).map(value -> BankAccounts.formatCurrency(value.balance)).orElse(null);
+                        if (args.length == 2)
+                            yield BankAccounts.formatCurrency(
+                                    Arrays.stream(Account.get(player))
+                                            .map(account -> account.balance)
+                                            .reduce(BigDecimal.ZERO, BigDecimal::add)
+                            );
+                        yield null;
+                    }
+                    default -> Account.get(Account.Tag.from(args[1])).map(value -> String.valueOf(value.balance)).orElse(null);
+                };
+            }
             case "owner" -> args.length < 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.owner.getName()).orElse(null);
             case "type" -> args.length < 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.type.getName()).orElse(null);
             case "name" -> args.length < 2 ? null : Account.get(Account.Tag.from(args[1])).map(value -> value.name).orElse(null);


### PR DESCRIPTION
Added several new PlaceholderAPI placeholders.

- `%bankaccounts_balance%` — the total balance of all of the player’s accounts (ex. `1234`)
- `%bankaccounts_balance_formatted%` — the formatted total balance of the player’s accounts (ex. `$1,234`)
- `%bankaccounts_account_list%` — comma-separated list of account IDs owned by the player
- `%bankaccounts_account_names%` — comma-separated list of account names owned by the player (uses IDs where names not available)
- `%bankaccounts_account_count%` — number of accounts the player has

Created wiki page: [Placeholders](https://github.com/cloudnode-pro/BankAccounts/wiki/Placeholders)

Related: #44